### PR TITLE
Write fields query differently to avoid namespace issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,15 +96,15 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "18.17.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.11.tgz",
-            "integrity": "sha512-r3hjHPBu+3LzbGBa8DHnr/KAeTEEOrahkcL+cZc4MaBMTM+mk8LtXR+zw+nqfjuDZZzYTYgTcpHuP+BEQk069g==",
+            "version": "18.18.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+            "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
             "dev": true
         },
         "node_modules/@urql/core": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.1.tgz",
-            "integrity": "sha512-iIoAy6BY+BUZZ7KIpnMT7C9q+ULf5ZCVxGe3/i7WZSJBrQa2h1QkIMhL+8fAKmOn9gt83jSIv5drWWnhZ9izEA==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.3.tgz",
+            "integrity": "sha512-Wapa58olpEJtZzSEuZNDxzBxmOmHuivG6Hb/QPc6HjHfCJ6f36gnlWc9a9TsC8Vddle+6PsS6+quMMTuj+bj7A==",
             "dependencies": {
                 "@0no-co/graphql.web": "^1.0.1",
                 "wonka": "^6.3.2"
@@ -161,16 +161,6 @@
             },
             "funding": {
                 "url": "https://github.com/motdotla/dotenv?sponsor=1"
-            }
-        },
-        "node_modules/graphql": {
-            "version": "16.8.0",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-            "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
         },
         "node_modules/make-error": {

--- a/src/restconfClient.ts
+++ b/src/restconfClient.ts
@@ -33,7 +33,7 @@ export class RestconfClient {
 
     public async getProfileIds(): Promise<string[]> {
         
-        const profiles = await this.getData('base:profiles/profile/?fields=id;type');
+        const profiles = await this.getData('base:profiles/profile/?depth=2');
         return profiles['base:profile']
             .filter((profile: any) => profile.type === 'profile-oauth:oauth-service')
             .map((profile: any) => profile.id);


### PR DESCRIPTION
Aim to work around an issue with the fields query that failed for a customer, but which we cannot reproduce. Using `fields=id;type` involves namespaces for the type field, which may be causing RESTCONF to get confused somehow. So hopefully using a depth query will prevent the issue:

```bash
curl "http://localhost:6749/admin/api/restconf/data/base:profiles/profile?depth=2" \
-u "admin:Password1" \
-H "accept: application/yang-data+json"
```

This should return a couple more fields as follows, but remains an efficient query, that brings back the id and type fields that the rest of the migration logic needs. We will ask the customer to verify that this query works before merging.

```json
{
  "base:profile": [
    {
      "id": "authentication-service",
      "type": "profile-authentication:authentication-service",
      "settings": {
      },
      "token-issuers": {
      }
    },
    {
      "id": "token-service",
      "type": "profile-oauth:oauth-service",
      "settings": {
      },
      "token-issuers": {
      }
    },
    {
      "id": "user-management",
      "type": "profile-user-management:user-management-service",
      "settings": {
      }
    }
  ]
}
```