### PR TITLE
Schema updates and fixes found during testing

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ MIGRATION_CLIENT_SECRET='Password1'
 MIGRATION_CLIENT_SCOPE='database-clients'
 MIGRATION_TAG='migrated-from-config'
 DELETE_MIGRATED_CLIENTS='false'
+MAX_CLIENTS='1000'
 
 # Can be used as a quick workaround when using untrusted SSL certs in development environments
 #NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/.env-DEV
+++ b/.env-DEV
@@ -9,6 +9,7 @@ MIGRATION_CLIENT_SECRET='Password1'
 MIGRATION_CLIENT_SCOPE='database-clients'
 MIGRATION_TAG='migrated-from-config'
 DELETE_MIGRATED_CLIENTS='false'
+MAX_CLIENTS='1000'
 
 # Can be used as a quick workaround when using untrusted SSL certs in development environments
 NODE_TLS_REJECT_UNAUTHORIZED=0

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ The migrated clients can now be managed from the DevOps dashboard:
 Once usage is understood, the same approach can be followed for real environments.\
 First ensure that you have a working backup of the configuration clients. \
 Start with test stages of the deployment pipeline, and do basic testing of your clients after the migration.\
-Reconfigure the `.env` file to point the Node.js app to the correct environment before running each migration:
+Reconfigure the `.env` file to point the Node.js app to the correct environment before running each migration.\
+Also ensure that `NUM_CLIENTS` is not lower than the total number of your configuration clients.
 
 ```text
 RESTCONF_USER='admin'
@@ -93,6 +94,7 @@ MIGRATION_CLIENT_SECRET='...'
 MIGRATION_CLIENT_SCOPE='database-clients'
 MIGRATION_TAG='migrated-from-config'
 DELETE_MIGRATED_CLIENTS='false'
+NUM_CLIENTS:1000
 ```
 
 ## More information

--- a/example-clients.xml
+++ b/example-clients.xml
@@ -67,6 +67,8 @@
                                 <client-name>Haapi Android Client</client-name>
                                 <no-authentication>true</no-authentication>
                                 <redirect-uris>app://haapi</redirect-uris>
+                                <user-authentication>
+                                </user-authentication>
                                 <audience>haapi-client</audience>
                                 <scope>address</scope>
                                 <scope>email</scope>

--- a/example-clients.xml
+++ b/example-clients.xml
@@ -133,6 +133,22 @@
                                 </assertion>
                                 </capabilities>
                             </client>
+                             <client>
+                                <id>implicit_client</id>
+                                <client-name>implicit_client</client-name>
+                                <redirect-uris>https://oauth.tools/callback/implicit</redirect-uris>
+                                <scope>openid</scope>
+                                <user-authentication>
+                                <allowed-authenticators>username</allowed-authenticators>
+                                </user-authentication>
+                                <capabilities>
+                                <implicit/>
+                                </capabilities>
+                                <use-pairwise-subject-identifiers>
+                                <sector-identifier>implicit_test</sector-identifier>
+                                </use-pairwise-subject-identifiers>
+                                <validate-port-on-loopback-interfaces>true</validate-port-on-loopback-interfaces>
+                            </client>
                         </config-backed>
                     </client-store>
                 </authorization-server>

--- a/example-clients.xml
+++ b/example-clients.xml
@@ -139,15 +139,34 @@
                                 <redirect-uris>https://oauth.tools/callback/implicit</redirect-uris>
                                 <scope>openid</scope>
                                 <user-authentication>
-                                <allowed-authenticators>username</allowed-authenticators>
+                                    <allowed-authenticators>username</allowed-authenticators>
                                 </user-authentication>
                                 <capabilities>
-                                <implicit/>
+                                    <implicit/>
                                 </capabilities>
                                 <use-pairwise-subject-identifiers>
-                                <sector-identifier>implicit_test</sector-identifier>
+                                    <sector-identifier>implicit_test</sector-identifier>
                                 </use-pairwise-subject-identifiers>
                                 <validate-port-on-loopback-interfaces>true</validate-port-on-loopback-interfaces>
+                            </client>
+                            <client>
+                                <id>secondary-secret-expiration-client</id>
+                                <client-name>A client for which an issue was found</client-name>
+                                <secret>$5$Mh4wCzhNzpIeAaiC$OGcoepRMuRrpp5CT36W5tUAXTfVUdBVujYkfDBzblJB</secret>
+                                <secondary-authentication-method>
+                                    <expires-on>2024-02-23T14:22:14.45+00:00</expires-on>
+                                    <secret>$5$Mh4wCzhNzpIeAaiC$OGcoepRMuRrpp5CT36W5tUAXTfVUdBVujYkfDBzblJB</secret>
+                                </secondary-authentication-method>
+                                <scope>profile</scope>
+                                <capabilities>
+                                <client-credentials/>
+                                </capabilities>
+                                <properties>
+                                    <property>
+                                        <key>MyProp1</key>
+                                        <value>Some test property</value>
+                                    </property>
+                                </properties>
                             </client>
                         </config-backed>
                     </client-store>

--- a/migration-configuration.xml
+++ b/migration-configuration.xml
@@ -21,6 +21,12 @@
           <database-client>
               <!-- Change this ID if importing settings into a test system, eg to a value like DefaultHSQLDB -->
               <client-data-source>default-datasource</client-data-source>
+              <client-tags>
+                <client-tag>
+                  <tag>migrated-from-config</tag>
+                  <description>Indicates that the client originated from configuration</description>
+                </client-tag>
+              </client-tags>
           </database-client>
           <scopes>
             <scope>
@@ -67,7 +73,7 @@
               <access-operation>read</access-operation>
               <access-operation>update</access-operation>
               <access-operation>delete</access-operation>
-              <attribute>dbClient.*</attribute>
+              <attribute>dbClient</attribute>
               <decision>allow</decision>
             </rule>
             <select-rule-list-when>

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,18 +13,18 @@
                 "dotenv": "^16.3.1"
             },
             "devDependencies": {
-                "@types/node": "^18.15.11",
-                "ts-node": "^10.9.1",
-                "typescript": "^5.1.3"
+                "@types/node": "^20.11.30",
+                "tsx": "^4.15.7",
+                "typescript": "^5.5.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@0no-co/graphql.web": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.4.tgz",
-            "integrity": "sha512-W3ezhHGfO0MS1PtGloaTpg0PbaT8aZSmmaerL7idtU5F7oCI+uu25k+MsMS31BVFlp4aMkHSrNRxiD72IlK8TA==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.7.tgz",
+            "integrity": "sha512-E3Qku4mTzdrlwVWGPxklDnME5ANrEGetvYw4i2GCRlppWXXE4QD66j7pwb8HelZwS6LnqEChhrSOGCXpbiu6MQ==",
             "peerDependencies": {
                 "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
             },
@@ -34,188 +34,499 @@
                 }
             }
         },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-            "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
             "dev": true,
-            "dependencies": {
-                "@jridgewell/trace-mapping": "0.3.9"
-            },
+            "optional": true,
+            "os": [
+                "aix"
+            ],
             "engines": {
                 "node": ">=12"
             }
         },
-        "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
             "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
             "engines": {
-                "node": ">=6.0.0"
+                "node": ">=12"
             }
         },
-        "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
-        },
-        "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
             "dev": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.0.3",
-                "@jridgewell/sourcemap-codec": "^1.4.10"
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-            "dev": true
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-            "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-            "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
-        "node_modules/@tsconfig/node16": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-            "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/@types/node": {
-            "version": "18.18.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
-            "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
-            "dev": true
+            "version": "20.14.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+            "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@urql/core": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.1.3.tgz",
-            "integrity": "sha512-Wapa58olpEJtZzSEuZNDxzBxmOmHuivG6Hb/QPc6HjHfCJ6f36gnlWc9a9TsC8Vddle+6PsS6+quMMTuj+bj7A==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@urql/core/-/core-4.3.0.tgz",
+            "integrity": "sha512-wT+FeL8DG4x5o6RfHEnONNFVDM3616ouzATMYUClB6CB+iIu2mwfBKd7xSUxYOZmwtxna5/hDRQdMl3nbQZlnw==",
             "dependencies": {
                 "@0no-co/graphql.web": "^1.0.1",
                 "wonka": "^6.3.2"
             }
         },
-        "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
-        },
-        "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
         "node_modules/dotenv": {
-            "version": "16.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+            "version": "16.4.5",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+            "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
             "engines": {
                 "node": ">=12"
             },
             "funding": {
-                "url": "https://github.com/motdotla/dotenv?sponsor=1"
+                "url": "https://dotenvx.com"
             }
         },
-        "node_modules/make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
+        "node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
+            }
         },
-        "node_modules/ts-node": {
-            "version": "10.9.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+        "node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.7.5",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+            "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
             "dev": true,
             "dependencies": {
-                "@cspotcode/source-map-support": "^0.8.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "v8-compile-cache-lib": "^3.0.1",
-                "yn": "3.1.1"
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
+        "node_modules/tsx": {
+            "version": "4.16.2",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.16.2.tgz",
+            "integrity": "sha512-C1uWweJDgdtX2x600HjaFaucXTilT7tgUZHbOE4+ypskZ1OP8CRCSDkCxG6Vya9EwaFIVagWwpaVAn5wzypaqQ==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "~0.21.5",
+                "get-tsconfig": "^4.7.5"
             },
             "bin": {
-                "ts-node": "dist/bin.js",
-                "ts-node-cwd": "dist/bin-cwd.js",
-                "ts-node-esm": "dist/bin-esm.js",
-                "ts-node-script": "dist/bin-script.js",
-                "ts-node-transpile-only": "dist/bin-transpile.js",
-                "ts-script": "dist/bin-script-deprecated.js"
+                "tsx": "dist/cli.mjs"
             },
-            "peerDependencies": {
-                "@swc/core": ">=1.2.50",
-                "@swc/wasm": ">=1.2.50",
-                "@types/node": "*",
-                "typescript": ">=2.7"
+            "engines": {
+                "node": ">=18.0.0"
             },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/wasm": {
-                    "optional": true
-                }
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
             }
         },
         "node_modules/typescript": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-            "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+            "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -225,25 +536,16 @@
                 "node": ">=14.17"
             }
         },
-        "node_modules/v8-compile-cache-lib": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-            "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true
         },
         "node_modules/wonka": {
             "version": "6.3.4",
             "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.4.tgz",
             "integrity": "sha512-CjpbqNtBGNAeyNS/9W6q3kSkKE52+FjIj7AkFlLr11s/VWGUu6a2CdYSdGxocIhIVjaW/zchesBQUKPVU69Cqg=="
-        },
-        "node_modules/yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@urql/core": "^4.1.1",
+                "@urql/core": "^4.3.0",
                 "dotenv": "^16.3.1"
             },
             "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
     "license": "Apache-2.0",
     "type": "module",
     "engines": {
-        "node": ">=18"
+        "node": ">=20"
     },
     "scripts": {
-        "start": "node --loader ts-node/esm --no-warnings src/index.ts"
+        "start": "tsx src/index.ts"
     },
     "dependencies": {
         "@urql/core": "^4.1.1",
         "dotenv": "^16.3.1"
     },
     "devDependencies": {
-        "@types/node": "^18.15.11",
-        "ts-node": "^10.9.1",
-        "typescript": "^5.1.3"
+        "@types/node": "^20.11.30",
+        "tsx": "^4.15.7",
+        "typescript": "^5.5.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "start": "tsx src/index.ts"
     },
     "dependencies": {
-        "@urql/core": "^4.1.1",
+        "@urql/core": "^4.3.0",
         "dotenv": "^16.3.1"
     },
     "devDependencies": {

--- a/src/data/clientMapper.ts
+++ b/src/data/clientMapper.ts
@@ -26,8 +26,8 @@ import {
     AsymmetricKeyManagementAlgorithm,
     BackchannelAuthentication,
     CapabilitiesInput,
-    ClientAuthenticationInput,
-    ClientAuthenticationVerifierInput,
+    ClientAuthenticationCreateInput,
+    ClientAuthenticationVerifierCreateInput,
     ClientCredentials,
     Code,
     ContentEncryptionAlgorithm,
@@ -35,7 +35,7 @@ import {
     DatabaseClientStatus,
     Disable,
     Haapi,
-    IdTokenInput,
+    IdTokenCreateInput,
     Implicit,
     Introspection,
     Ios,
@@ -282,7 +282,7 @@ export class ClientMapper {
         return capabilities;
     }
 
-    private getClientAuthentication(configClient: ConfigurationClient): ClientAuthenticationInput {
+    private getClientAuthentication(configClient: ConfigurationClient): ClientAuthenticationCreateInput {
 
         const secondary = configClient['secondary-authentication-method']
         return {
@@ -292,7 +292,7 @@ export class ClientMapper {
         };
     }
 
-    private getPrimaryClientAuthentication(configClient: ConfigurationClient): ClientAuthenticationVerifierInput {
+    private getPrimaryClientAuthentication(configClient: ConfigurationClient): ClientAuthenticationVerifierCreateInput {
 
         if (configClient['asymmetric-key']) {
 
@@ -331,7 +331,7 @@ export class ClientMapper {
         }
     }
 
-    private getSecondaryClientAuthentication(configClient: ConfigurationClient): ClientAuthenticationVerifierInput | null {
+    private getSecondaryClientAuthentication(configClient: ConfigurationClient): ClientAuthenticationVerifierCreateInput | null {
 
         const secondary = configClient['secondary-authentication-method']
         if (secondary) {
@@ -394,7 +394,7 @@ export class ClientMapper {
         }
     }
 
-    private getIdToken(configClient: ConfigurationClient): IdTokenInput | null {
+    private getIdToken(configClient: ConfigurationClient): IdTokenCreateInput | null {
 
         const idTokenTtl = configClient['id-token-ttl'];
         const idTokenEncryption = configClient['id-token-encryption'];
@@ -402,7 +402,7 @@ export class ClientMapper {
             return null;
         }
 
-        let idToken: IdTokenInput = {};
+        let idToken: IdTokenCreateInput = {};
         if (idTokenTtl) {
             idToken.id_token_ttl = idTokenTtl;
         }

--- a/src/data/clientMapper.ts
+++ b/src/data/clientMapper.ts
@@ -318,7 +318,7 @@ export class ClientMapper {
                 },
             };
 
-        } else if (configClient['no-authentication'] || configClient.capabilities['assisted-token']) {
+        } else if (configClient['no-authentication'] || configClient.capabilities['implicit'] || configClient.capabilities['assisted-token']) {
 
             return {
                 no_authentication: NoAuth.NoAuth,

--- a/src/data/clientMapper.ts
+++ b/src/data/clientMapper.ts
@@ -284,11 +284,11 @@ export class ClientMapper {
 
     private getClientAuthentication(configClient: ConfigurationClient): ClientAuthenticationCreateInput {
 
-        const secondary = configClient['secondary-authentication-method']
+        const secondary = configClient['secondary-authentication-method'];
         return {
             primary: this.getPrimaryClientAuthentication(configClient),
             secondary: this.getSecondaryClientAuthentication(configClient),
-            secondary_verifier_expiration: secondary?.['expires-on'] ? Date.parse(secondary['expires-on']) / 1000.0 : null,
+            secondary_verifier_expiration: secondary?.['expires-on'] ? Math.floor(Date.parse(secondary['expires-on']) / 1000.0) : null,
         };
     }
 

--- a/src/data/databaseClient.ts
+++ b/src/data/databaseClient.ts
@@ -1,3 +1,19 @@
+/*
+ *  Copyright 2024 Curity AB
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/src/data/databaseClient.ts
+++ b/src/data/databaseClient.ts
@@ -1,19 +1,3 @@
-/*
- *  Copyright 2023 Curity AB
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
-
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
@@ -43,6 +27,11 @@ export enum Android {
 /** Android client attestation configuration */
 export type AndroidAttestation = {
   __typename?: 'AndroidAttestation';
+  /**
+   * Whether to disable attestation validation.
+   * This is a debug-only option and must not be used in production environments.
+   */
+  disable_validation: Scalars['Boolean']['output'];
   /** Android package names that should be allowed to perform client attestation */
   package_names: Array<Scalars['String']['output']>;
   /** Attestation policy ID */
@@ -55,14 +44,19 @@ export type AndroidAttestation = {
 
 /** Android client attestation configuration */
 export type AndroidAttestationInput = {
+  /**
+   * Whether to disable attestation validation.
+   * This is a debug-only option and must not be used in production environments.
+   */
+  disable_validation?: InputMaybe<Scalars['Boolean']['input']>;
   /** Android package names that should be allowed to perform client attestation */
-  package_names: Array<Scalars['String']['input']>;
+  package_names?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Attestation policy ID */
   policy_id?: InputMaybe<Scalars['String']['input']>;
   /** Android package signature fingerprints that should be allowed to perform client attestation */
-  signature_fingerprints: Array<Scalars['String']['input']>;
+  signature_fingerprints?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Type of client attestation */
-  type: Android;
+  type?: InputMaybe<Android>;
 };
 
 /** Assertion capability type */
@@ -93,7 +87,7 @@ export type AssertionCapabilityInput = {
   /** Configures the assertion grant for JWT assertions. */
   jwt: JwtAssertionInput;
   /** Type of the assertion capability */
-  type: Assertion;
+  type?: InputMaybe<Assertion>;
 };
 
 /** Assisted token capability type */
@@ -124,7 +118,7 @@ export type AssistedTokenCapability = {
  */
 export type AssistedTokenCapabilityInput = {
   /** Type of the assisted token capability */
-  type: AssistedToken;
+  type?: InputMaybe<AssistedToken>;
 };
 
 /** Asymmetric key configuration */
@@ -212,14 +206,14 @@ export type BackchannelAuthenticationCapabilityInput = {
    */
   allowed_backchannel_authenticators?: InputMaybe<Array<Scalars['String']['input']>>;
   /** Type of the backchannel authentication capability */
-  type: BackchannelAuthentication;
+  type?: InputMaybe<BackchannelAuthentication>;
 };
 
 /** Request Object by-ref configuration */
 export type ByRefRequestObject = {
   __typename?: 'ByRefRequestObject';
   /** If set to true, then unsigned request objects sent by-reference will be accepted. */
-  allow_unsigned_for?: Maybe<Scalars['Boolean']['output']>;
+  allow_unsigned_for: Scalars['Boolean']['output'];
   /**
    * Locations that can be included in a request_uri parameter.
    * The value '*' allows for any.
@@ -239,7 +233,7 @@ export type ByRefRequestObjectInput = {
    * The value '*' allows for any.
    * A wildcard character '*' is also allowed at the end of the uri value.
    */
-  allowed_request_urls: Array<Scalars['String']['input']>;
+  allowed_request_urls?: InputMaybe<Array<Scalars['String']['input']>>;
   /** The HTTP client that will be used when fetching the request object from a provided URI. */
   http_client_id?: InputMaybe<Scalars['String']['input']>;
 };
@@ -267,9 +261,11 @@ export type Capabilities = {
   implicit?: Maybe<ImplicitCapability>;
   /** Introspection capability */
   introspection?: Maybe<IntrospectionCapability>;
+  /** OAuth Token exchange capability */
+  oauth_token_exchange?: Maybe<OAuthTokenExchangeCapability>;
   /** Resource-owner password credentials capability */
   resource_owner_password?: Maybe<ResourceOwnerPasswordCredentialsCapability>;
-  /** Token exchange capability */
+  /** Custom Token exchange capability */
   token_exchange?: Maybe<TokenExchangeCapability>;
 };
 
@@ -295,9 +291,11 @@ export type CapabilitiesInput = {
   implicit?: InputMaybe<ImplicitCapabilityInput>;
   /** Introspection capability */
   introspection?: InputMaybe<IntrospectionCapabilityInput>;
+  /** OAuth Token exchange capability */
+  oauth_token_exchange?: InputMaybe<OAuthTokenExchangeCapabilityInput>;
   /** Resource-owner password credentials capability */
   resource_owner_password?: InputMaybe<ResourceOwnerPasswordCredentialsCapabilityInput>;
-  /** Token exchange capability */
+  /** Custom Token exchange capability */
   token_exchange?: InputMaybe<TokenExchangeCapabilityInput>;
 };
 
@@ -336,15 +334,33 @@ export type ClientAuthentication = {
 };
 
 /** Describes how the client is authenticated */
-export type ClientAuthenticationInput = {
+export type ClientAuthenticationCreateInput = {
   /** The primary way to authenticate this client. */
-  primary: ClientAuthenticationVerifierInput;
+  primary: ClientAuthenticationVerifierCreateInput;
   /**
    * Optional additional client authentication method, used if the primary one was unsuccessful.
    *
    * Allows for high-availability during credential rotation or authentication method upgrades.
    */
-  secondary?: InputMaybe<ClientAuthenticationVerifierInput>;
+  secondary?: InputMaybe<ClientAuthenticationVerifierCreateInput>;
+  /**
+   * The instant after which the secondary verifier should not be used.
+   *
+   * The unit of this value is epoch-seconds.
+   */
+  secondary_verifier_expiration?: InputMaybe<Scalars['Long']['input']>;
+};
+
+/** Describes how the client is authenticated */
+export type ClientAuthenticationUpdateInput = {
+  /** The primary way to authenticate this client. */
+  primary?: InputMaybe<ClientAuthenticationVerifierUpdateInput>;
+  /**
+   * Optional additional client authentication method, used if the primary one was unsuccessful.
+   *
+   * Allows for high-availability during credential rotation or authentication method upgrades.
+   */
+  secondary?: InputMaybe<ClientAuthenticationVerifierUpdateInput>;
   /**
    * The instant after which the secondary verifier should not be used.
    *
@@ -354,18 +370,44 @@ export type ClientAuthenticationInput = {
 };
 
 /** Client authentication verifier */
-export type ClientAuthenticationVerifier = AsymmetricKey | CredentialManager | MutualTlsByProxyVerifier | MutualTlsVerifier | NoAuthentication | Secret | SymmetricKey;
+export type ClientAuthenticationVerifier = AsymmetricKey | CredentialManager | Jwks | JwksUriVerifier | MutualTlsByProxyVerifier | MutualTlsVerifier | NoAuthentication | Secret | SymmetricKey;
 
 /** This is an union type. Only one of the fields must be set. */
-export type ClientAuthenticationVerifierInput = {
+export type ClientAuthenticationVerifierCreateInput = {
   /** Asymmetric key */
   asymmetric?: InputMaybe<AsymmetricKeyInput>;
   /** Credential manager */
   credential_manager?: InputMaybe<CredentialManagerInput>;
+  /** JWKS (asymmetric key authentication). */
+  jwks_object?: InputMaybe<JwksInput>;
+  /** JWKS URI (asymmetric key authentication) */
+  jwks_uri?: InputMaybe<JwksUriCreateInput>;
   /** Mutual TLS authentication */
-  mutual_tls?: InputMaybe<MutualTlsInput>;
+  mutual_tls?: InputMaybe<MutualTlsCreateInput>;
   /** Mutual TLS by proxy authentication */
-  mutual_tls_by_proxy?: InputMaybe<MutualTlsInput>;
+  mutual_tls_by_proxy?: InputMaybe<MutualTlsCreateInput>;
+  /** Disable client authentication */
+  no_authentication?: InputMaybe<NoAuth>;
+  /** Client secret */
+  secret?: InputMaybe<SecretInput>;
+  /** Symmetric key */
+  symmetric?: InputMaybe<SymmetricKeyInput>;
+};
+
+/** This is an union type. Only one of the fields must be set. */
+export type ClientAuthenticationVerifierUpdateInput = {
+  /** Asymmetric key */
+  asymmetric?: InputMaybe<AsymmetricKeyInput>;
+  /** Credential manager */
+  credential_manager?: InputMaybe<CredentialManagerInput>;
+  /** JWKS (asymmetric key authentication) */
+  jwks_object?: InputMaybe<JwksInput>;
+  /** JWKS URI (asymmetric key authentication) */
+  jwks_uri?: InputMaybe<JwksUriInput>;
+  /** Mutual TLS authentication */
+  mutual_tls?: InputMaybe<MutualTlsUpdateInput>;
+  /** Mutual TLS by proxy authentication */
+  mutual_tls_by_proxy?: InputMaybe<MutualTlsUpdateInput>;
   /** Disable client authentication */
   no_authentication?: InputMaybe<NoAuth>;
   /** Client secret */
@@ -398,7 +440,7 @@ export type ClientCredentialsCapability = {
  */
 export type ClientCredentialsCapabilityInput = {
   /** Type of the client-credentials capability */
-  type: ClientCredentials;
+  type?: InputMaybe<ClientCredentials>;
 };
 
 /** Code flow capability type */
@@ -441,7 +483,7 @@ export type CodeCapabilityInput = {
    */
   require_pushed_authorization_request?: InputMaybe<Scalars['Boolean']['input']>;
   /** Type of the code capability */
-  type: Code;
+  type?: InputMaybe<Code>;
 };
 
 /** User consent configuration */
@@ -529,7 +571,7 @@ export type DatabaseClient = {
    * The optional list of URIs or URI-patterns that is allowed to embed the rendered pages inside
    * an iframe, be a trusted source or be used for CORS.
    */
-  allowed_origins?: Maybe<Array<Scalars['String']['output']>>;
+  allowed_origins: Array<Scalars['String']['output']>;
   /**
    * This URL is used if a request is made to the OAuth server without the parameters necessary
    * to initiate authentication.
@@ -571,7 +613,7 @@ export type DatabaseClient = {
    */
   logo_uri?: Maybe<Scalars['String']['output']>;
   /** Metadata related to this client. */
-  meta?: Maybe<Meta>;
+  meta: Meta;
   /** A human readable name of the client. */
   name: Scalars['String']['output'];
   /**
@@ -593,7 +635,7 @@ export type DatabaseClient = {
    * The client redirect URIs.
    * Mandatory if the client has the [CodeCapability].
    */
-  redirect_uris?: Maybe<Array<Scalars['String']['output']>>;
+  redirect_uris: Array<Scalars['String']['output']>;
   /**
    * Configuration for Refresh Tokens.
    * If not set, refresh tokens are automatically issued when the client is configured with one of the following
@@ -636,7 +678,7 @@ export type DatabaseClient = {
    */
   subject_type: SubjectType;
   /** Optional list of tags categorizing this client, thus allowing to easily filter clients in chosen categories. */
-  tags?: Maybe<Array<Scalars['String']['output']>>;
+  tags: Array<Scalars['String']['output']>;
   /** An absolute URL that refers to the terms of service of the client. */
   tos_uri?: Maybe<Scalars['String']['output']>;
   /** Enable client to perform user authentication. */
@@ -711,7 +753,7 @@ export type DatabaseClientCreateFields = {
    * One must be selected. For public clients, select a primary method
    * of `NoAuthentication`.
    */
-  client_authentication?: InputMaybe<ClientAuthenticationInput>;
+  client_authentication?: InputMaybe<ClientAuthenticationCreateInput>;
   /**
    * OAuth client_id, unique only within a single profile.
    *
@@ -721,7 +763,7 @@ export type DatabaseClientCreateFields = {
   /** A human readable description of the client. */
   description?: InputMaybe<Scalars['String']['input']>;
   /** Configuration for ID Tokens. */
-  id_token?: InputMaybe<IdTokenInput>;
+  id_token?: InputMaybe<IdTokenCreateInput>;
   /**
    * A logo of the client, that can shown in user interface templates.
    *
@@ -762,7 +804,7 @@ export type DatabaseClientCreateFields = {
    */
   require_secured_authorization_response?: InputMaybe<Scalars['Boolean']['input']>;
   /** The scopes of this client. */
-  scopes: Array<Scalars['String']['input']>;
+  scopes?: InputMaybe<Array<Scalars['String']['input']>>;
   /**
    * The sector identifier that is used to derive the pairwise pseudonym from,
    * i.e. the pairwise pseudonym is defined for the pair of sector identifier and subject.
@@ -881,11 +923,11 @@ export type DatabaseClientUpdateFields = {
    * One must be selected. For public clients, select a primary method
    * of `NoAuthentication`.
    */
-  client_authentication?: InputMaybe<ClientAuthenticationInput>;
+  client_authentication?: InputMaybe<ClientAuthenticationUpdateInput>;
   /** A human readable description of the client. */
   description?: InputMaybe<Scalars['String']['input']>;
   /** Configuration for ID Tokens. */
-  id_token?: InputMaybe<IdTokenInput>;
+  id_token?: InputMaybe<IdTokenUpdateInput>;
   /**
    * A logo of the client, that can shown in user interface templates.
    *
@@ -1000,13 +1042,23 @@ export type DnMutualTls = NameAndCa & {
 };
 
 /** DN Mutual TLS Authentication */
-export type DnMutualTlsInput = {
+export type DnMutualTlsCreateInput = {
   /** The DN of the client certificate that the client must identify with. */
   client_dn: Scalars['String']['input'];
   /** RDNs to match. */
-  rdns_to_match: Array<Scalars['String']['input']>;
+  rdns_to_match?: InputMaybe<Array<Scalars['String']['input']>>;
   /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
-  trusted_cas: Array<Scalars['String']['input']>;
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** DN Mutual TLS Authentication */
+export type DnMutualTlsUpdateInput = {
+  /** The DN of the client certificate that the client must identify with. */
+  client_dn?: InputMaybe<Scalars['String']['input']>;
+  /** RDNs to match. */
+  rdns_to_match?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** DNs Mutual TLS Authentication */
@@ -1022,14 +1074,36 @@ export type DnsMutualTls = NameAndCa & {
 };
 
 /** DNs Mutual TLS Authentication */
-export type DnsMutualTlsInput = {
+export type DnsMutualTlsCreateInput = {
   /**
    * The expected dNSName SAN entry in the certificate that the client
    * must identify with.
    */
   client_dns: Scalars['String']['input'];
   /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
-  trusted_cas: Array<Scalars['String']['input']>;
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** DNs Mutual TLS Authentication */
+export type DnsMutualTlsUpdateInput = {
+  /**
+   * The expected dNSName SAN entry in the certificate that the client
+   * must identify with.
+   */
+  client_dns?: InputMaybe<Scalars['String']['input']>;
+  /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** Input of the duplicate operation. */
+export type DuplicateDatabaseClientByIdInput = {
+  /** The client to duplicate. */
+  client_id: Scalars['ID']['input'];
+  /**
+   * The ID of the new client.
+   * If not provided, an ID is auto-generated.
+   */
+  new_client_id?: InputMaybe<Scalars['ID']['input']>;
 };
 
 /** Email Mutual TLS Authentication */
@@ -1045,14 +1119,25 @@ export type EmailMutualTls = NameAndCa & {
 };
 
 /** Email Mutual TLS Authentication */
-export type EmailMutualTlsInput = {
+export type EmailMutualTlsCreateInput = {
   /**
    * The expected rfc822Name SAN entry in the certificate that the client
    * must identify with.
    */
   client_email: Scalars['String']['input'];
   /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
-  trusted_cas: Array<Scalars['String']['input']>;
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** Email Mutual TLS Authentication */
+export type EmailMutualTlsUpdateInput = {
+  /**
+   * The expected rfc822Name SAN entry in the certificate that the client
+   * must identify with.
+   */
+  client_email?: InputMaybe<Scalars['String']['input']>;
+  /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** HAAPI (Hypermedia authentication API) capability type */
@@ -1077,6 +1162,8 @@ export type HaapiCapability = {
    * It is not allowed to use NoAttestation with a public client.
    */
   client_attestation: ClientAttestation;
+  /** Issue token bound authorization code and refresh token. */
+  issue_token_bound_authorization_code: Scalars['Boolean']['output'];
   /** Type of the HAAPI capability */
   type: Haapi;
   /**
@@ -1102,15 +1189,17 @@ export type HaapiCapabilityInput = {
    * For this reason, if this is not set, the client must NOT set `client_authentication` to `NoAuthentication`.
    */
   client_attestation?: InputMaybe<ClientAttestationInput>;
+  /** Issue token bound authorization code and refresh token. */
+  issue_token_bound_authorization_code?: InputMaybe<Scalars['Boolean']['input']>;
   /** Type of the HAAPI capability */
-  type: Haapi;
+  type?: InputMaybe<Haapi>;
   /**
    * Use an older version of the DPoP processing, which is not nonce-based.
    *
    * This may be required if the client uses an older version of the HAAPI SDK.
    * Refer to the HAAPI SDK documentation for details.
    */
-  use_legacy_dpop: Scalars['Boolean']['input'];
+  use_legacy_dpop?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Configuration of ID tokens. */
@@ -1127,13 +1216,25 @@ export type IdToken = {
 };
 
 /** Configuration of ID tokens. */
-export type IdTokenInput = {
+export type IdTokenCreateInput = {
   /**
    * Enables ID Token Encryption as per JWE specification."
    *
    * The profile must enable id-token encryption before a client can configure it.
    */
-  id_token_encryption?: InputMaybe<JweEncryptionInput>;
+  id_token_encryption?: InputMaybe<JweEncryptionCreateInput>;
+  /** The Time to Live for an id token. If not set, the profile-setting is used. */
+  id_token_ttl?: InputMaybe<Scalars['Long']['input']>;
+};
+
+/** Configuration of ID tokens. */
+export type IdTokenUpdateInput = {
+  /**
+   * Enables ID Token Encryption as per JWE specification."
+   *
+   * The profile must enable id-token encryption before a client can configure it.
+   */
+  id_token_encryption?: InputMaybe<JweEncryptionUpdateInput>;
   /** The Time to Live for an id token. If not set, the profile-setting is used. */
   id_token_ttl?: InputMaybe<Scalars['Long']['input']>;
 };
@@ -1181,7 +1282,7 @@ export type IntrospectionCapability = {
  */
 export type IntrospectionCapabilityInput = {
   /** Type of the token introspection capability */
-  type: Introspection;
+  type?: InputMaybe<Introspection>;
 };
 
 /** IOS client attestation */
@@ -1195,6 +1296,11 @@ export type IosAttestation = {
   __typename?: 'IosAttestation';
   /** IOS App ID that should be allowed to perform client attestation */
   app_id: Scalars['String']['output'];
+  /**
+   * Whether to disable attestation validation.
+   * This is a debug-only option and must not be used in production environments.
+   */
+  disable_validation: Scalars['Boolean']['output'];
   /** Attestation policy ID */
   policy_id?: Maybe<Scalars['String']['output']>;
   /** Type of client attestation */
@@ -1205,10 +1311,15 @@ export type IosAttestation = {
 export type IosAttestationInput = {
   /** IOS App ID that should be allowed to perform client attestation */
   app_id: Scalars['String']['input'];
+  /**
+   * Whether to disable attestation validation.
+   * This is a debug-only option and must not be used in production environments.
+   */
+  disable_validation?: InputMaybe<Scalars['Boolean']['input']>;
   /** Attestation policy ID */
   policy_id?: InputMaybe<Scalars['String']['input']>;
   /** Type of client attestation */
-  type: Ios;
+  type?: InputMaybe<Ios>;
 };
 
 /** IP Mutual TLS Authentication */
@@ -1225,7 +1336,7 @@ export type IpMutualTls = NameAndCa & {
 };
 
 /** IP Mutual TLS Authentication */
-export type IpMutualTlsInput = {
+export type IpMutualTlsCreateInput = {
   /**
    * The expected IP address in either dotted decimal notation (for IPv4)
    * or colon-delimited hexadecimal (for IPv6) that is expected to be present as
@@ -1233,7 +1344,19 @@ export type IpMutualTlsInput = {
    */
   client_ip: Scalars['String']['input'];
   /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
-  trusted_cas: Array<Scalars['String']['input']>;
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** IP Mutual TLS Authentication */
+export type IpMutualTlsUpdateInput = {
+  /**
+   * The expected IP address in either dotted decimal notation (for IPv4)
+   * or colon-delimited hexadecimal (for IPv6) that is expected to be present as
+   * an iPAddress SAN entry in the certificate that the client must identify with.
+   */
+  client_ip?: InputMaybe<Scalars['String']['input']>;
+  /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** JWE encryption configuration */
@@ -1248,13 +1371,36 @@ export type JweEncryption = {
 };
 
 /** JWE encryption configuration */
-export type JweEncryptionInput = {
+export type JweEncryptionCreateInput = {
   /** Supported content encryption algorithms, present as 'enc' in JWE header. */
   allowed_content_encryption_alg: ContentEncryptionAlgorithm;
   /** Algorithms supported to encrypt the content encryption key, present as 'alg' in JWE header. */
   allowed_key_management_alg: AsymmetricKeyManagementAlgorithm;
   /** Encryption key ID */
   encryption_key_id: Scalars['String']['input'];
+};
+
+/** JWE encryption configuration */
+export type JweEncryptionUpdateInput = {
+  /** Supported content encryption algorithms, present as 'enc' in JWE header. */
+  allowed_content_encryption_alg?: InputMaybe<ContentEncryptionAlgorithm>;
+  /** Algorithms supported to encrypt the content encryption key, present as 'alg' in JWE header. */
+  allowed_key_management_alg?: InputMaybe<AsymmetricKeyManagementAlgorithm>;
+  /** Encryption key ID */
+  encryption_key_id?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** JWKS configuration */
+export type Jwks = {
+  __typename?: 'Jwks';
+  /** A JWKS object as a base64-encoded JSON String */
+  jwks: Scalars['String']['output'];
+};
+
+/** JWKS configuration */
+export type JwksInput = {
+  /** A JWKS object as a JSON String. The String should be base64-encoded to prevent encoding issues. */
+  jwks: Scalars['String']['input'];
 };
 
 /** A key present in a JWKS referenced by an URI, accessed via an optional HTTP client ID. */
@@ -1267,11 +1413,26 @@ export type JwksUri = {
 };
 
 /** A key present in a JWKS referenced by an URI, accessed via an optional HTTP client ID. */
-export type JwksUriInput = {
+export type JwksUriCreateInput = {
   /** The optional HTTP client used to retrieve the JWKS. */
   http_client_id?: InputMaybe<Scalars['String']['input']>;
   /** The JWKS URI. */
   uri: Scalars['String']['input'];
+};
+
+/** A key present in a JWKS referenced by an URI, accessed via an optional HTTP client ID. */
+export type JwksUriInput = {
+  /** The optional HTTP client used to retrieve the JWKS. */
+  http_client_id?: InputMaybe<Scalars['String']['input']>;
+  /** The JWKS URI. */
+  uri?: InputMaybe<Scalars['String']['input']>;
+};
+
+/** JWKS URI client authentication verifier */
+export type JwksUriVerifier = {
+  __typename?: 'JwksUriVerifier';
+  /** JWKS URI used to authenticate the client */
+  jwks_uri: JwksUri;
 };
 
 /** JWT assertion configuration */
@@ -1304,11 +1465,11 @@ export type JwtAssertionInput = {
    * The assertion capability must be enabled in the profile with allowed algorithms
    * for the selected signing option.
    */
-  signing: JwtSigningInput;
+  signing?: InputMaybe<JwtSigningInput>;
 };
 
 /** JWT signing configuration */
-export type JwtSigning = AsymmetricKey | JwksUri | SymmetricKey;
+export type JwtSigning = AsymmetricKey | Jwks | JwksUri | SymmetricKey;
 
 /** This is an union type. Only one of the fields must be set. */
 export type JwtSigningInput = {
@@ -1316,6 +1477,8 @@ export type JwtSigningInput = {
   asymmetric_key?: InputMaybe<AsymmetricKeyInput>;
   /** JWKS URI */
   jwks?: InputMaybe<JwksUriInput>;
+  /** JWKS Object */
+  jwks_object?: InputMaybe<JwksInput>;
   /** Symmetric key */
   symmetric_key?: InputMaybe<SymmetricKeyInput>;
 };
@@ -1327,6 +1490,8 @@ export type Meta = {
   created: Scalars['Long']['output'];
   /** Instant the resource was last modified (in epoch-seconds). */
   lastModified: Scalars['Long']['output'];
+  /** Attribute validation warnings. */
+  warnings?: Maybe<Scalars['Object']['output']>;
 };
 
 /** Mutation definitions. */
@@ -1343,6 +1508,12 @@ export type Mutation = {
    * If a client with the given ID does not exist, an error occurs.
    */
   deleteDatabaseClientById?: Maybe<DeleteDatabaseClientPayload>;
+  /**
+   * Duplicates a client.
+   *
+   * If a client with the given ID does not exist, null is returned.
+   */
+  duplicateDatabaseClientById?: Maybe<CreateDatabaseClientPayload>;
   /** Updates the owner of a given database client. */
   setDatabaseClientOwnerById?: Maybe<SetDatabaseClientOwnerPayload>;
   /**
@@ -1357,9 +1528,15 @@ export type Mutation = {
    * Complex fields are NOT merged, i.e. they are replaced completely if provided.
    * For example, for a list field:
    * * If the list field is not provided: the current list value is left untouched
-   * * If the list field is provided with a null or empty value: the current list value is removed
-   * * If a non-empty list field is provided: the current list value is replaced.
-   * If a client with the given ID does not exist, an error occurs.
+   * * If the list field is provided with a `null` or empty list: the current list
+   * value is removed or replaced by its default value if applicable
+   * * If a non-empty list field is provided: the current list value is replaced
+   * If a client with the given ID does not exist, `null` is returned.
+   * Map fields (e.g. `properties`) are handled as follows:
+   * * If the map field is not provided: the current map value is left untouched
+   * * If the map field is provided with a `null` value: the current map value is removed
+   * * If a map field is provided: the provided key/value pairs are merged with the
+   * current map’s value, or removed if their value is `null`.
    */
   updateDatabaseClientById?: Maybe<UpdateDatabaseClientPayload>;
 };
@@ -1374,6 +1551,12 @@ export type MutationCreateDatabaseClientArgs = {
 /** Mutation definitions. */
 export type MutationDeleteDatabaseClientByIdArgs = {
   input: DeleteDatabaseClientByIdInput;
+};
+
+
+/** Mutation definitions. */
+export type MutationDuplicateDatabaseClientByIdArgs = {
+  input: DuplicateDatabaseClientByIdInput;
 };
 
 
@@ -1395,7 +1578,7 @@ export type MutationUpdateDatabaseClientByIdArgs = {
 };
 
 /** Mutual TLS Authentication */
-export type MutualTls = DnMutualTls | DnsMutualTls | EmailMutualTls | IpMutualTls | PinnedCertificate | TrustedCaOnly | UriMutualTls;
+export type MutualTls = DnMutualTls | DnsMutualTls | EmailMutualTls | IpMutualTls | PinnedCertificate | PinnedCertificatePem | TrustedCaOnly | UriMutualTls;
 
 /** Enable client authentication through mutual-tls by-proxy. */
 export type MutualTlsByProxyVerifier = {
@@ -1409,17 +1592,19 @@ export type MutualTlsByProxyVerifier = {
 };
 
 /** This is an union type. Only one of the fields must be set. */
-export type MutualTlsInput = {
+export type MutualTlsCreateInput = {
   /** DN Mutual TLS Authentication */
-  dn?: InputMaybe<DnMutualTlsInput>;
+  dn?: InputMaybe<DnMutualTlsCreateInput>;
   /** DNs Mutual TLS Authentication */
-  dns?: InputMaybe<DnsMutualTlsInput>;
+  dns?: InputMaybe<DnsMutualTlsCreateInput>;
   /** Email Mutual TLS Authentication */
-  email?: InputMaybe<EmailMutualTlsInput>;
+  email?: InputMaybe<EmailMutualTlsCreateInput>;
   /** IP Mutual TLS Authentication */
-  ip?: InputMaybe<IpMutualTlsInput>;
+  ip?: InputMaybe<IpMutualTlsCreateInput>;
   /** The client certificate that must be used to authenticate the client. */
   pinned_certificate?: InputMaybe<PinnedCertificateInput>;
+  /** The client certificate that must be used to authenticate the client. */
+  pinned_certificate_pem?: InputMaybe<PinnedCertificatePemInput>;
   /**
    * The CA's that can be the issuer of the client certificate that can be accepted
    * to authenticate this client.
@@ -1427,7 +1612,31 @@ export type MutualTlsInput = {
    */
   trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
   /** URI Mutual TLS Authentication */
-  uri?: InputMaybe<UriMutualTlsInput>;
+  uri?: InputMaybe<UriMutualTlsCreateInput>;
+};
+
+/** This is an union type. Only one of the fields must be set. */
+export type MutualTlsUpdateInput = {
+  /** DN Mutual TLS Authentication */
+  dn?: InputMaybe<DnMutualTlsUpdateInput>;
+  /** DNs Mutual TLS Authentication */
+  dns?: InputMaybe<DnsMutualTlsUpdateInput>;
+  /** Email Mutual TLS Authentication */
+  email?: InputMaybe<EmailMutualTlsUpdateInput>;
+  /** IP Mutual TLS Authentication */
+  ip?: InputMaybe<IpMutualTlsUpdateInput>;
+  /** The client certificate that must be used to authenticate the client. */
+  pinned_certificate?: InputMaybe<PinnedCertificateInput>;
+  /** The client certificate that must be used to authenticate the client. */
+  pinned_certificate_pem?: InputMaybe<PinnedCertificatePemInput>;
+  /**
+   * The CA's that can be the issuer of the client certificate that can be accepted
+   * to authenticate this client.
+   * If empty, then all profile certificates may be used to authenticate the client.
+   */
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
+  /** URI Mutual TLS Authentication */
+  uri?: InputMaybe<UriMutualTlsUpdateInput>;
 };
 
 /** Enable client authentication through direct mutual-tls. */
@@ -1451,14 +1660,20 @@ export type NameAndCa = {
   trusted_cas: Array<Scalars['String']['output']>;
 };
 
-/** Disable client attestation */
+/**
+ * Disable client attestation.
+ * This is equivalent to `allow-without-attestation=true` for configuration clients.
+ */
 export type NoAttestation = {
   __typename?: 'NoAttestation';
   /** Type of client attestation */
   type: Disable;
 };
 
-/** No attestation. */
+/**
+ * No attestation.
+ * The client will not need to perform client attestation, but it must authenticate instead.
+ */
 export type NoAttestationInput = {
   /** Type of no attestation. */
   type: Disable;
@@ -1482,6 +1697,33 @@ export type NoAuthentication = {
   no_authentication: NoAuth;
 };
 
+/** Token exchange capability type */
+export enum OAuthTokenExchange {
+  /** OAuth Token exchange capability type */
+  OauthTokenExchange = 'OAUTH_TOKEN_EXCHANGE'
+}
+
+/**
+ * Allows the client to use exchange tokens for other tokens (as per https://datatracker.ietf.org/doc/html/rfc8693).
+ *
+ * When enabled, the client must NOT set `client_authentication` to `NoAuthentication`.
+ */
+export type OAuthTokenExchangeCapability = {
+  __typename?: 'OAuthTokenExchangeCapability';
+  /** Type of the token exchange capability */
+  type: OAuthTokenExchange;
+};
+
+/**
+ * Allows the client to exchange tokens for other tokens (as per https://datatracker.ietf.org/doc/html/rfc8693).
+ *
+ * When enabled, the client must NOT set `client_authentication` to `NoAuthentication`.
+ */
+export type OAuthTokenExchangeCapabilityInput = {
+  /** Type of the token exchange capability */
+  type?: InputMaybe<OAuthTokenExchange>;
+};
+
 /** Information about pagination in a connection */
 export type PageInfo = {
   __typename?: 'PageInfo';
@@ -1498,10 +1740,23 @@ export type PinnedCertificate = {
   client_certificate_id: Scalars['String']['output'];
 };
 
-/** Pinned Certificate Mutual TLS Authentication */
+/** Reference to Pinned Certificate Mutual TLS Authentication */
 export type PinnedCertificateInput = {
   /** The ID of a client certificate that must be used to authenticate the client. */
   client_certificate_id: Scalars['String']['input'];
+};
+
+/** Pinned Certificate Mutual TLS Authentication present in PEM format */
+export type PinnedCertificatePem = {
+  __typename?: 'PinnedCertificatePem';
+  /** The client certificate that must be used to authenticate the client in PEM format. */
+  client_certificate_pem: Scalars['String']['output'];
+};
+
+/** Pinned Certificate Mutual TLS Authentication in PEM format */
+export type PinnedCertificatePemInput = {
+  /** The client certificate that must be used to authenticate the client in PEM format */
+  client_certificate_pem: Scalars['String']['input'];
 };
 
 /**
@@ -1536,7 +1791,7 @@ export type ProofKeyInput = {
    * Enforces this client to provide a proof key challenge and -verifier when performing
    * the Authorization Code Grant flow.
    */
-  require_proof_key: Scalars['Boolean']['input'];
+  require_proof_key?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 /** Query definitions. */
@@ -1550,6 +1805,13 @@ export type Query = {
    * Only clients satisfying ALL provided arguments will be returned.
    */
   databaseClients: DatabaseClientConnection;
+  /**
+   * Search for database clients using provided search term or terms.
+   * When multiple terms are provided, they must be space separated.
+   * To match the filter, all terms must be found in the client ID, or all be found in client name.
+   * Database clients matching a subset of the terms in client ID, and other terms in the client name are not returned.
+   */
+  searchDatabaseClients: DatabaseClientConnection;
 };
 
 
@@ -1567,6 +1829,16 @@ export type QueryDatabaseClientsArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   sorting?: InputMaybe<DatabaseClientSorting>;
   tags?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+
+/** Query definitions. */
+export type QuerySearchDatabaseClientsArgs = {
+  activeClientsOnly?: InputMaybe<Scalars['Boolean']['input']>;
+  after?: InputMaybe<Scalars['String']['input']>;
+  first?: InputMaybe<Scalars['Int']['input']>;
+  searchTerms?: InputMaybe<Scalars['String']['input']>;
+  sorting?: InputMaybe<DatabaseClientSorting>;
 };
 
 /** Configuration of refresh tokens. */
@@ -1598,7 +1870,7 @@ export type RefreshTokenInput = {
    */
   refresh_token_max_rolling_lifetime?: InputMaybe<Scalars['Long']['input']>;
   /** The Time To Live for a Refresh token. */
-  refresh_token_ttl: Scalars['Long']['input'];
+  refresh_token_ttl?: InputMaybe<Scalars['Long']['input']>;
   /**
    * Defines if refresh tokens are created on every refresh or if they are kept.
    * When set, this takes precedence over profile setting (reuse-refresh-tokens),
@@ -1616,7 +1888,7 @@ export type RequestObject = {
    * Enabling unsigned request objects requires the 'none' algorithm to be in the profile's
    * request object allowed algorithms.
    */
-  allow_unsigned_for_by_value?: Maybe<Scalars['Boolean']['output']>;
+  allow_unsigned_for_by_value: Scalars['Boolean']['output'];
   /** Enable the use of request object that are sent by-reference using the request_uri parameter. */
   by_reference?: Maybe<ByRefRequestObject>;
   /**
@@ -1747,7 +2019,9 @@ export enum SortAttribute {
   /** Created. */
   Created = 'created',
   /** Last modified. */
-  LastModified = 'lastModified'
+  LastModified = 'lastModified',
+  /** Sort by resource name. Which field is used for sorting depends on the resource type. */
+  Name = 'name'
 }
 
 /** Sort order. */
@@ -1761,7 +2035,7 @@ export enum SortOrder {
 /** Sorting. */
 export type Sorting = {
   /** Sort by attribute. */
-  sortBy: SortAttribute;
+  sortBy?: InputMaybe<SortAttribute>;
   /** Sort order. */
   sortOrder: SortOrder;
 };
@@ -1809,7 +2083,7 @@ export type SymmetricKeyInput = {
 
 /** Token exchange capability type */
 export enum TokenExchange {
-  /** Token exchange capability type */
+  /** Custom Token exchange capability type */
   TokenExchange = 'TOKEN_EXCHANGE'
 }
 
@@ -1825,13 +2099,13 @@ export type TokenExchangeCapability = {
 };
 
 /**
- * Allows the client to use exchange tokens for other tokens.
+ * Allows the client to exchange tokens for other tokens.
  *
  * When enabled, the client must NOT set `client_authentication` to `NoAuthentication`.
  */
 export type TokenExchangeCapabilityInput = {
   /** Type of the token exchange capability */
-  type: TokenExchange;
+  type?: InputMaybe<TokenExchange>;
 };
 
 /** Trusted CA (only) Mutual TLS Authentication */
@@ -1869,14 +2143,25 @@ export type UriMutualTls = NameAndCa & {
 };
 
 /** URI Mutual TLS Authentication */
-export type UriMutualTlsInput = {
+export type UriMutualTlsCreateInput = {
   /**
    * The expected uniformResourceIdentifier SAN entry in the certificate
    * that the client must identify with.
    */
   client_uri: Scalars['String']['input'];
   /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
-  trusted_cas: Array<Scalars['String']['input']>;
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
+};
+
+/** URI Mutual TLS Authentication */
+export type UriMutualTlsUpdateInput = {
+  /**
+   * The expected uniformResourceIdentifier SAN entry in the certificate
+   * that the client must identify with.
+   */
+  client_uri?: InputMaybe<Scalars['String']['input']>;
+  /** The CAs trusted by this client. If empty, all of the CAs configured in the server are used. */
+  trusted_cas?: InputMaybe<Array<Scalars['String']['input']>>;
 };
 
 /** User authentication configuration */
@@ -1904,7 +2189,7 @@ export type UserAuthentication = {
   /** Information that will be displayed to the user when authenticating the client */
   context_info: Scalars['String']['output'];
   /** Whether user authentication is forced at all times. */
-  force_authentication?: Maybe<Scalars['Boolean']['output']>;
+  force_authentication: Scalars['Boolean']['output'];
   /** Optional maximum age in seconds after which re-authentication must take place. */
   freshness?: Maybe<Scalars['Long']['output']>;
   /**
@@ -1947,7 +2232,7 @@ export type UserAuthenticationInput = {
    */
   consent?: InputMaybe<ConsentInput>;
   /** Information that will be displayed to the user when authenticating the client */
-  context_info: Scalars['String']['input'];
+  context_info?: InputMaybe<Scalars['String']['input']>;
   /** Optional default setting whether user authentication is forced at all times. */
   force_authentication?: InputMaybe<Scalars['Boolean']['input']>;
   /** Optional maximum age in seconds after which re-authentication must take place. */
@@ -1997,6 +2282,11 @@ export enum Web {
 /** Web client attestation configuration */
 export type WebAttestation = {
   __typename?: 'WebAttestation';
+  /**
+   * Whether to disable attestation validation.
+   * This is a debug-only option and must not be used in production environments.
+   */
+  disable_validation: Scalars['Boolean']['output'];
   /** Attestation policy ID */
   policy_id?: Maybe<Scalars['String']['output']>;
   /** Type of client attestation */
@@ -2005,8 +2295,13 @@ export type WebAttestation = {
 
 /** Web client attestation configuration */
 export type WebAttestationInput = {
+  /**
+   * Whether to disable attestation validation.
+   * This is a debug-only option and must not be used in production environments.
+   */
+  disable_validation?: InputMaybe<Scalars['Boolean']['input']>;
   /** Attestation policy ID */
   policy_id?: InputMaybe<Scalars['String']['input']>;
   /** Type of client attestation */
-  type: Web;
+  type?: InputMaybe<Web>;
 };

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -31,6 +31,7 @@ export interface Environment {
     migrationClientScope: string;
     migrationTag: string;
     deleteMigratedClients: boolean;
+    numClients: string;
 }
 
 /*
@@ -49,6 +50,7 @@ export function getEnvironment(): Environment {
         migrationClientScope: getEnvironmentVariable("MIGRATION_CLIENT_SCOPE"),
         migrationTag: getEnvironmentVariable("MIGRATION_TAG"),
         deleteMigratedClients: getEnvironmentVariable("DELETE_MIGRATED_CLIENTS") === 'true',
+        numClients: getEnvironmentVariable('MAX_CLIENTS'),
     };
 }
 

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -78,7 +78,7 @@ export class GraphqlClient {
 
         const query = gql`
             query getDatabaseClients {
-                databaseClients {
+                databaseClients(first: 1000) {
                     edges {
                         node {
                             client_id

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -18,8 +18,9 @@ import {Client, ClientOptions, fetchExchange, gql} from '@urql/core';
 import {CreateDatabaseClientInput, CreateDatabaseClientPayload} from './data/databaseClient.js';
 import {Environment} from './environment.js';
 import {getHttpErrorAsText, getGraphqlErrorAsText} from './utils.js'
-        
+
 /*
+
  * A class to send database client information to GraphQL APIs
  */
 export class GraphqlClient {
@@ -130,7 +131,6 @@ export class GraphqlClient {
            exchanges: [fetchExchange],
         };
         const client = new Client(options);
-
         const mutation = gql`
             mutation createDatabaseClient($input: CreateDatabaseClientInput!) {
                 createDatabaseClient(input: $input ) {

--- a/src/graphqlClient.ts
+++ b/src/graphqlClient.ts
@@ -78,7 +78,7 @@ export class GraphqlClient {
 
         const query = gql`
             query getDatabaseClients {
-                databaseClients(first: 1000) {
+                databaseClients(first: ${this.environment.numClients}) {
                     edges {
                         node {
                             client_id

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {ClientMapper} from './data/clientMapper.js'
 import {getEnvironment, isClientToMigrate} from './environment.js'
 import {RestconfClient} from './restconfClient.js'
 import {GraphqlClient} from './graphqlClient.js'
-import { MigratedClient } from './migratedClient.js';
+import {MigratedClient} from './migratedClient.js';
 
 console.log('Preparing environment ...');
 const environment = getEnvironment();

--- a/typegenerator/generate.sh
+++ b/typegenerator/generate.sh
@@ -21,7 +21,6 @@ if [ "$HTTP_STATUS" != '200'  ]; then
   exit 1
 fi
 ACCESS_TOKEN=$(cat data.txt | jq -r .access_token)
-echo $ACCESS_TOKEN
 
 #
 # Get the schema

--- a/typegenerator/package-lock.json
+++ b/typegenerator/package-lock.json
@@ -9,15 +9,15 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@graphql-codegen/cli": "5.0.0",
-                "@graphql-codegen/client-preset": "^4.1.0",
-                "@graphql-codegen/typescript": "4.0.1",
+                "@graphql-codegen/cli": "^5.0.0",
+                "@graphql-codegen/client-preset": "^4.3.2",
+                "@graphql-codegen/typescript": "^4.0.1",
                 "get-graphql-schema": "^2.1.2",
-                "graphql": "^16.8.0",
+                "graphql": "^16.9.0",
                 "typescript": "^5.5.2"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@ampproject/remapping": {

--- a/typegenerator/package-lock.json
+++ b/typegenerator/package-lock.json
@@ -14,20 +14,20 @@
                 "@graphql-codegen/typescript": "4.0.1",
                 "get-graphql-schema": "^2.1.2",
                 "graphql": "^16.8.0",
-                "typescript": "^5.1.3"
+                "typescript": "^5.5.2"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@ampproject/remapping": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
-            "integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
@@ -129,106 +129,44 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
-            "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+            "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.22.10",
-                "chalk": "^2.4.2"
+                "@babel/highlight": "^7.24.7",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-            "dev": true
-        },
-        "node_modules/@babel/code-frame/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/@babel/code-frame/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/@babel/compat-data": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.9.tgz",
-            "integrity": "sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.24.7.tgz",
+            "integrity": "sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.11.tgz",
-            "integrity": "sha512-lh7RJrtPdhibbxndr6/xx0w8+CVlY5FJZiaSz908Fpy+G0xkBFTvwLcKJFF4PJxVfGhVWNebikpWGnOoC71juQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.7.tgz",
+            "integrity": "sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-compilation-targets": "^7.22.10",
-                "@babel/helper-module-transforms": "^7.22.9",
-                "@babel/helpers": "^7.22.11",
-                "@babel/parser": "^7.22.11",
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.11",
-                "@babel/types": "^7.22.11",
-                "convert-source-map": "^1.7.0",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.24.7",
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helpers": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/template": "^7.24.7",
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7",
+                "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
                 "json5": "^2.2.3",
@@ -243,14 +181,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
-            "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
+            "integrity": "sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.10",
-                "@jridgewell/gen-mapping": "^0.3.2",
-                "@jridgewell/trace-mapping": "^0.3.17",
+                "@babel/types": "^7.24.7",
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^2.5.1"
             },
             "engines": {
@@ -258,26 +196,26 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-            "integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+            "integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
-            "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.24.7.tgz",
+            "integrity": "sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.22.9",
-                "@babel/helper-validator-option": "^7.22.5",
-                "browserslist": "^4.21.9",
+                "@babel/compat-data": "^7.24.7",
+                "@babel/helper-validator-option": "^7.24.7",
+                "browserslist": "^4.22.2",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
             },
@@ -286,19 +224,19 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.22.11.tgz",
-            "integrity": "sha512-y1grdYL4WzmUDBRGK0pDbIoFd7UZKoDurDzWEoNMYoj1EL+foGRQNyPWDcC+YyegN5y1DUsFFmzjGijB3nSVAQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.7.tgz",
+            "integrity": "sha512-kTkaDl7c9vO80zeX1rJxnuRpEsD5tA81yh11X1gQo+PhSti3JS+7qeZo9U4RHobKRiFPKaGK3svUAeb8D0Q7eg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/helper-member-expression-to-functions": "^7.22.5",
-                "@babel/helper-optimise-call-expression": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.9",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-member-expression-to-functions": "^7.24.7",
+                "@babel/helper-optimise-call-expression": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -309,74 +247,79 @@
             }
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
+            "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
             "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.24.7"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
+            "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-            "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
+            "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.22.5.tgz",
-            "integrity": "sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.7.tgz",
+            "integrity": "sha512-LGeMaf5JN4hAT471eJdBs/GK1DoYIJ5GCtZN/EsL6KUiiDZOvO/eKE11AMZJa2zP4zk4qe9V2O/hxAmkRc8p6w==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.5.tgz",
-            "integrity": "sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+            "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.22.9.tgz",
-            "integrity": "sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.7.tgz",
+            "integrity": "sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.5",
-                "@babel/helper-simple-access": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/helper-validator-identifier": "^7.22.5"
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-simple-access": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -386,35 +329,35 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
-            "integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+            "integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-            "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+            "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.22.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.9.tgz",
-            "integrity": "sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.24.7.tgz",
+            "integrity": "sha512-qTAxxBM81VEyoAY0TtLrx1oAEJc09ZK67Q9ljQToqCnA+55eNwCORaxlKyu+rNfX86o8OXRUSNUnrtsAZXM9sg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-member-expression-to-functions": "^7.22.5",
-                "@babel/helper-optimise-call-expression": "^7.22.5"
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-member-expression-to-functions": "^7.24.7",
+                "@babel/helper-optimise-call-expression": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -424,91 +367,93 @@
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-            "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+            "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-            "integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+            "integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/traverse": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
+            "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5"
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.7.tgz",
+            "integrity": "sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+            "integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.5.tgz",
-            "integrity": "sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+            "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.11.tgz",
-            "integrity": "sha512-vyOXC8PBWaGc5h7GMsNx68OH33cypkEDJCHvYVVgVbbxJDROYVtexSk0gK5iCF1xNjRIN2s8ai7hwkWDq5szWg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.7.tgz",
+            "integrity": "sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/traverse": "^7.22.11",
-                "@babel/types": "^7.22.11"
+                "@babel/template": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
-            "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+            "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "chalk": "^2.4.2",
-                "js-tokens": "^4.0.0"
+                "js-tokens": "^4.0.0",
+                "picocolors": "^1.0.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -577,9 +522,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.11.tgz",
-            "integrity": "sha512-R5zb8eJIBPJriQtbH/htEQy4k7E2dHWlD2Y2VT07JCzwYZHBxV5ZYtM0UhXSNMT74LyxuM+b1jdL7pSesXbC/g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
+            "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -592,6 +537,7 @@
             "version": "7.18.6",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
             "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
+            "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
             "dev": true,
             "dependencies": {
                 "@babel/helper-create-class-features-plugin": "^7.18.6",
@@ -608,6 +554,7 @@
             "version": "7.20.7",
             "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
             "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
+            "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.20.5",
@@ -636,12 +583,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-flow": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
-            "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
+            "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -651,12 +598,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.22.5.tgz",
-            "integrity": "sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.7.tgz",
+            "integrity": "sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -666,12 +613,12 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
-            "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+            "integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -693,12 +640,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.22.5.tgz",
-            "integrity": "sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.24.7.tgz",
+            "integrity": "sha512-Dt9LQs6iEY++gXUwY03DNFat5C2NbO48jj+j/bSAz6b3HgPs39qcPiYt77fDObIcFwj3/C2ICX9YMwGflUoSHQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -708,12 +655,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.22.5.tgz",
-            "integrity": "sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.24.7.tgz",
+            "integrity": "sha512-yO7RAz6EsVQDaBH18IDJcMB1HnrUn2FJ/Jslc/WtPPWcjhpUJXU/rjbwmluzp7v/ZzWcEhTMXELnnsz8djWDwQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -723,12 +670,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.22.10.tgz",
-            "integrity": "sha512-1+kVpGAOOI1Albt6Vse7c8pHzcZQdQKW+wJH+g8mCaszOdDVwRXa/slHPqIw+oJAJANTKDMuM2cBdV0Dg618Vg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.7.tgz",
+            "integrity": "sha512-Nd5CvgMbWc+oWzBsuaMcbwjJWAcp5qzrbg69SZdHSP7AMY0AbWFqFO0WTFCA1jxhMCwodRwvRec8k0QUbZk7RQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -738,19 +685,18 @@
             }
         },
         "node_modules/@babel/plugin-transform-classes": {
-            "version": "7.22.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.22.6.tgz",
-            "integrity": "sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.24.7.tgz",
+            "integrity": "sha512-CFbbBigp8ln4FU6Bpy6g7sE8B/WmCmzvivzUC6xDAdWVsjYTXijpuuGJmYkAaoWAzcItGKT3IOAbxRItZ5HTjw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-compilation-targets": "^7.22.6",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/helper-optimise-call-expression": "^7.22.5",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -761,13 +707,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.22.5.tgz",
-            "integrity": "sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.24.7.tgz",
+            "integrity": "sha512-25cS7v+707Gu6Ds2oY6tCkUwsJ9YIDbggd9+cu9jzzDgiNq7hR/8dkzxWfKWnTic26vsI3EsCXNd4iEB6e8esQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/template": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/template": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -777,12 +723,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-destructuring": {
-            "version": "7.22.10",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.22.10.tgz",
-            "integrity": "sha512-dPJrL0VOyxqLM9sritNbMSGx/teueHF/htMKrPT7DNxccXxRDPYqlgPFFdr8u+F+qUZOkZoXue/6rL5O5GduEw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.24.7.tgz",
+            "integrity": "sha512-19eJO/8kdCQ9zISOf+SEUJM/bAUIsvY3YDnXZTupUCQ8LgrWnsG/gFB9dvXqdXnRXMAM8fvt7b0CBKQHNGy1mw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -792,13 +738,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-flow-strip-types": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.22.5.tgz",
-            "integrity": "sha512-tujNbZdxdG0/54g/oua8ISToaXTFBf8EnSb5PgQSciIXWOWKX3S4+JR7ZE9ol8FZwf9kxitzkGQ+QWeov/mCiA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.7.tgz",
+            "integrity": "sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/plugin-syntax-flow": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/plugin-syntax-flow": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -808,12 +754,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-for-of": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.22.5.tgz",
-            "integrity": "sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.24.7.tgz",
+            "integrity": "sha512-wo9ogrDG1ITTTBsy46oGiN1dS9A7MROBTcYsfS8DtsImMkHk9JXJ3EWQM6X2SUw4x80uGPlwj0o00Uoc6nEE3g==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -823,14 +770,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.22.5.tgz",
-            "integrity": "sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.24.7.tgz",
+            "integrity": "sha512-U9FcnA821YoILngSmYkW6FjyQe2TyZD5pHt4EVIhmcTkrJw/3KqcrRSxuOo5tFZJi7TE19iDyI1u+weTI7bn2w==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-compilation-targets": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-compilation-targets": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -840,12 +787,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-literals": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.22.5.tgz",
-            "integrity": "sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.24.7.tgz",
+            "integrity": "sha512-vcwCbb4HDH+hWi8Pqenwnjy+UiklO4Kt1vfspcQYFhJdpthSnW8XvWGyDZWKNVrVbVViI/S7K9PDJZiUmP2fYQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -855,12 +802,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.22.5.tgz",
-            "integrity": "sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.24.7.tgz",
+            "integrity": "sha512-T/hRC1uqrzXMKLQ6UCwMT85S3EvqaBXDGf0FaMf4446Qx9vKwlghvee0+uuZcDUCZU5RuNi4781UQ7R308zzBw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -870,14 +817,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.22.11.tgz",
-            "integrity": "sha512-o2+bg7GDS60cJMgz9jWqRUsWkMzLCxp+jFDeDUT5sjRlAxcJWZ2ylNdI7QQ2+CH5hWu7OnN+Cv3htt7AkSf96g==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.7.tgz",
+            "integrity": "sha512-iFI8GDxtevHJ/Z22J5xQpVqFLlMNstcLXh994xifFwxxGslr2ZXXLWgtBeLctOD63UFDArdvN6Tg8RFw+aEmjQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-module-transforms": "^7.22.9",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-simple-access": "^7.22.5"
+                "@babel/helper-module-transforms": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-simple-access": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -887,13 +834,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-object-super": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.22.5.tgz",
-            "integrity": "sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.24.7.tgz",
+            "integrity": "sha512-A/vVLwN6lBrMFmMDmPPz0jnE6ZGx7Jq7d6sT/Ev4H65RER6pZ+kczlf1DthF5N0qaPHBsI7UXiE8Zy66nmAovg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-replace-supers": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-replace-supers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -903,12 +850,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-parameters": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.22.5.tgz",
-            "integrity": "sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.24.7.tgz",
+            "integrity": "sha512-yGWW5Rr+sQOhK0Ot8hjDJuxU3XLRQGflvT4lhlSY0DFvdb3TwKaY26CJzHtYllU0vT9j58hc37ndFPsqT1SrzA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -918,12 +865,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-property-literals": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.22.5.tgz",
-            "integrity": "sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.24.7.tgz",
+            "integrity": "sha512-EMi4MLQSHfd2nrCqQEWxFdha2gBCqU4ZcCng4WBGZ5CJL4bBRW0ptdqqDdeirGZcpALazVVNJqRmsO8/+oNCBA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -933,12 +880,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.22.5.tgz",
-            "integrity": "sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.24.7.tgz",
+            "integrity": "sha512-H/Snz9PFxKsS1JLI4dJLtnJgCJRoo0AUm3chP6NYr+9En1JMKloheEiLIhlp5MDVznWo+H3AAC1Mc8lmUEpsgg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -948,16 +895,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.22.5.tgz",
-            "integrity": "sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.24.7.tgz",
+            "integrity": "sha512-+Dj06GDZEFRYvclU6k4bme55GKBEWUmByM/eoKuqg4zTNQHiApWRhQph5fxQB2wAEFvRzL1tOEj1RJ19wJrhoA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-annotate-as-pure": "^7.22.5",
-                "@babel/helper-module-imports": "^7.22.5",
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/plugin-syntax-jsx": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/helper-annotate-as-pure": "^7.24.7",
+                "@babel/helper-module-imports": "^7.24.7",
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/plugin-syntax-jsx": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -967,12 +914,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.22.5.tgz",
-            "integrity": "sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.24.7.tgz",
+            "integrity": "sha512-KsDsevZMDsigzbA09+vacnLpmPH4aWjcZjXdyFKGzpplxhbeB4wYtury3vglQkg6KM/xEPKt73eCjPPf1PgXBA==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -982,13 +929,13 @@
             }
         },
         "node_modules/@babel/plugin-transform-spread": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.22.5.tgz",
-            "integrity": "sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.24.7.tgz",
+            "integrity": "sha512-x96oO0I09dgMDxJaANcRyD4ellXFLLiWhuwDxKZX5g2rWP1bTPkBSwCYv96VDXVT1bD9aPj8tppr5ITIh8hBng==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -998,12 +945,12 @@
             }
         },
         "node_modules/@babel/plugin-transform-template-literals": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.22.5.tgz",
-            "integrity": "sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.24.7.tgz",
+            "integrity": "sha512-AfDTQmClklHCOLxtGoP7HkeMw56k1/bTQjwsfhL6pppo/M4TOBSq+jjBUBLmV/4oeFg4GWMavIl44ZeCtmmZTw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.22.5"
+                "@babel/helper-plugin-utils": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1013,9 +960,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
-            "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.7.tgz",
+            "integrity": "sha512-UwgBRMjJP+xv857DCngvqXI3Iq6J4v0wXmwc6sapg+zyhbwmQX67LUEFrkK5tbyJ30jGuG3ZvWpBiB9LCy1kWw==",
             "dev": true,
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
@@ -1025,34 +972,34 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-            "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
+            "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/code-frame": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.11.tgz",
-            "integrity": "sha512-mzAenteTfomcB7mfPtyi+4oe5BZ6MXxWcn4CX+h4IRJ+OOGXBrWU6jDQavkQI9Vuc5P+donFabBfFCcmWka9lQ==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.7.tgz",
+            "integrity": "sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.10",
-                "@babel/generator": "^7.22.10",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
-                "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.6",
-                "@babel/parser": "^7.22.11",
-                "@babel/types": "^7.22.11",
-                "debug": "^4.1.0",
+                "@babel/code-frame": "^7.24.7",
+                "@babel/generator": "^7.24.7",
+                "@babel/helper-environment-visitor": "^7.24.7",
+                "@babel/helper-function-name": "^7.24.7",
+                "@babel/helper-hoist-variables": "^7.24.7",
+                "@babel/helper-split-export-declaration": "^7.24.7",
+                "@babel/parser": "^7.24.7",
+                "@babel/types": "^7.24.7",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -1060,13 +1007,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.11",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-            "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.7.tgz",
+            "integrity": "sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-string-parser": "^7.24.7",
+                "@babel/helper-validator-identifier": "^7.24.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -1074,23 +1021,17 @@
             }
         },
         "node_modules/@graphql-codegen/add": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-5.0.0.tgz",
-            "integrity": "sha512-ynWDOsK2yxtFHwcJTB9shoSkUd7YXd6ZE57f0nk7W5cu/nAgxZZpEsnTPEpZB/Mjf14YRGe2uJHQ7AfElHjqUQ==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/add/-/add-5.0.3.tgz",
+            "integrity": "sha512-SxXPmramkth8XtBlAHu4H4jYcYXM/o3p01+psU+0NADQowA8jtYkK6MW5rV6T+CxkEaNZItfSmZRPgIuypcqnA==",
             "dev": true,
             "dependencies": {
-                "@graphql-codegen/plugin-helpers": "^5.0.0",
-                "tslib": "~2.5.0"
+                "@graphql-codegen/plugin-helpers": "^5.0.3",
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
-        },
-        "node_modules/@graphql-codegen/add/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
         },
         "node_modules/@graphql-codegen/cli": {
             "version": "5.0.0",
@@ -1150,82 +1091,80 @@
             }
         },
         "node_modules/@graphql-codegen/client-preset": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-4.1.0.tgz",
-            "integrity": "sha512-/3Ymb/fjxIF1+HGmaI1YwSZbWsrZAWMSQjh3dU425eBjctjsVQ6gzGRr+l/gE5F1mtmCf+vlbTAT03heAc/QIw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/client-preset/-/client-preset-4.3.2.tgz",
+            "integrity": "sha512-42jHyG6u2uFDIVNvzue8zR529aPT16EYIJQmvMk8XuYHo3PneQVlWmQ3j2fBy+RuWCBzpJKPKm7IGSKiw19nmg==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.20.2",
                 "@babel/template": "^7.20.7",
-                "@graphql-codegen/add": "^5.0.0",
-                "@graphql-codegen/gql-tag-operations": "4.0.1",
-                "@graphql-codegen/plugin-helpers": "^5.0.1",
-                "@graphql-codegen/typed-document-node": "^5.0.1",
-                "@graphql-codegen/typescript": "^4.0.1",
-                "@graphql-codegen/typescript-operations": "^4.0.1",
-                "@graphql-codegen/visitor-plugin-common": "^4.0.1",
+                "@graphql-codegen/add": "^5.0.3",
+                "@graphql-codegen/gql-tag-operations": "4.0.9",
+                "@graphql-codegen/plugin-helpers": "^5.0.4",
+                "@graphql-codegen/typed-document-node": "^5.0.9",
+                "@graphql-codegen/typescript": "^4.0.9",
+                "@graphql-codegen/typescript-operations": "^4.2.3",
+                "@graphql-codegen/visitor-plugin-common": "^5.3.1",
                 "@graphql-tools/documents": "^1.0.0",
                 "@graphql-tools/utils": "^10.0.0",
                 "@graphql-typed-document-node/core": "3.2.0",
-                "tslib": "~2.5.0"
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
         },
-        "node_modules/@graphql-codegen/client-preset/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
+        "node_modules/@graphql-codegen/client-preset/node_modules/@graphql-codegen/typescript": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.0.9.tgz",
+            "integrity": "sha512-0O35DMR4d/ctuHL1Zo6mRUUzp0BoszKfeWsa6sCm/g70+S98+hEfTwZNDkQHylLxapiyjssF9uw/F+sXqejqLw==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^5.0.4",
+                "@graphql-codegen/schema-ast": "^4.0.2",
+                "@graphql-codegen/visitor-plugin-common": "5.3.1",
+                "auto-bind": "~4.0.0",
+                "tslib": "~2.6.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
         },
         "node_modules/@graphql-codegen/core": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-4.0.0.tgz",
-            "integrity": "sha512-JAGRn49lEtSsZVxeIlFVIRxts2lWObR+OQo7V2LHDJ7ohYYw3ilv7nJ8pf8P4GTg/w6ptcYdSdVVdkI8kUHB/Q==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/core/-/core-4.0.2.tgz",
+            "integrity": "sha512-IZbpkhwVqgizcjNiaVzNAzm/xbWT6YnGgeOLwVjm4KbJn3V2jchVtuzHH09G5/WkkLSk2wgbXNdwjM41JxO6Eg==",
             "dev": true,
             "dependencies": {
-                "@graphql-codegen/plugin-helpers": "^5.0.0",
+                "@graphql-codegen/plugin-helpers": "^5.0.3",
                 "@graphql-tools/schema": "^10.0.0",
                 "@graphql-tools/utils": "^10.0.0",
-                "tslib": "~2.5.0"
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
-        },
-        "node_modules/@graphql-codegen/core/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
         },
         "node_modules/@graphql-codegen/gql-tag-operations": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-4.0.1.tgz",
-            "integrity": "sha512-qF6wIbBzW8BNT+wiVsBxrYOs2oYcsxQ7mRvCpfEI3HnNZMAST/uX76W8MqFEJvj4mw7NIDv7xYJAcAZIWM5LWw==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/gql-tag-operations/-/gql-tag-operations-4.0.9.tgz",
+            "integrity": "sha512-lVgu1HClel896HqZAEjynatlU6eJrYOw+rh05DPgM150xvmb7Gz5TnRHA2vfwlDNIXDaToAIpz5RFfkjjnYM1Q==",
             "dev": true,
             "dependencies": {
-                "@graphql-codegen/plugin-helpers": "^5.0.0",
-                "@graphql-codegen/visitor-plugin-common": "4.0.1",
+                "@graphql-codegen/plugin-helpers": "^5.0.4",
+                "@graphql-codegen/visitor-plugin-common": "5.3.1",
                 "@graphql-tools/utils": "^10.0.0",
                 "auto-bind": "~4.0.0",
-                "tslib": "~2.5.0"
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
         },
-        "node_modules/@graphql-codegen/gql-tag-operations/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
-        },
         "node_modules/@graphql-codegen/plugin-helpers": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.0.1.tgz",
-            "integrity": "sha512-6L5sb9D8wptZhnhLLBcheSPU7Tg//DGWgc5tQBWX46KYTOTQHGqDpv50FxAJJOyFVJrveN9otWk9UT9/yfY4ww==",
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-5.0.4.tgz",
+            "integrity": "sha512-MOIuHFNWUnFnqVmiXtrI+4UziMTYrcquljaI5f/T/Bc7oO7sXcfkAvgkNWEEi9xWreYwvuer3VHCuPI/lAFWbw==",
             "dev": true,
             "dependencies": {
                 "@graphql-tools/utils": "^10.0.0",
@@ -1233,59 +1172,41 @@
                 "common-tags": "1.8.2",
                 "import-from": "4.0.0",
                 "lodash": "~4.17.0",
-                "tslib": "~2.5.0"
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
-        },
-        "node_modules/@graphql-codegen/plugin-helpers/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
         },
         "node_modules/@graphql-codegen/schema-ast": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.0.0.tgz",
-            "integrity": "sha512-WIzkJFa9Gz28FITAPILbt+7A8+yzOyd1NxgwFh7ie+EmO9a5zQK6UQ3U/BviirguXCYnn+AR4dXsoDrSrtRA1g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/schema-ast/-/schema-ast-4.1.0.tgz",
+            "integrity": "sha512-kZVn0z+th9SvqxfKYgztA6PM7mhnSZaj4fiuBWvMTqA+QqQ9BBed6Pz41KuD/jr0gJtnlr2A4++/0VlpVbCTmQ==",
             "dev": true,
             "dependencies": {
-                "@graphql-codegen/plugin-helpers": "^5.0.0",
+                "@graphql-codegen/plugin-helpers": "^5.0.3",
                 "@graphql-tools/utils": "^10.0.0",
-                "tslib": "~2.5.0"
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
-        },
-        "node_modules/@graphql-codegen/schema-ast/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
         },
         "node_modules/@graphql-codegen/typed-document-node": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-5.0.1.tgz",
-            "integrity": "sha512-VFkhCuJnkgtbbgzoCAwTdJe2G1H6sd3LfCrDqWUrQe53y2ukfSb5Ov1PhAIkCBStKCMQBUY9YgGz9GKR40qQ8g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typed-document-node/-/typed-document-node-5.0.9.tgz",
+            "integrity": "sha512-Wx6fyA4vpfIbfNTMiWUECGnjqzKkJdEbZHxVMIegiCBPzBYPAJV4mZZcildLAfm2FtZcgW4YKtFoTbnbXqPB3w==",
             "dev": true,
             "dependencies": {
-                "@graphql-codegen/plugin-helpers": "^5.0.0",
-                "@graphql-codegen/visitor-plugin-common": "4.0.1",
+                "@graphql-codegen/plugin-helpers": "^5.0.4",
+                "@graphql-codegen/visitor-plugin-common": "5.3.1",
                 "auto-bind": "~4.0.0",
                 "change-case-all": "1.0.15",
-                "tslib": "~2.5.0"
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
-        },
-        "node_modules/@graphql-codegen/typed-document-node/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
         },
         "node_modules/@graphql-codegen/typescript": {
             "version": "4.0.1",
@@ -1304,34 +1225,38 @@
             }
         },
         "node_modules/@graphql-codegen/typescript-operations": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.0.1.tgz",
-            "integrity": "sha512-GpUWWdBVUec/Zqo23aFLBMrXYxN2irypHqDcKjN78JclDPdreasAEPcIpMfqf4MClvpmvDLy4ql+djVAwmkjbw==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript-operations/-/typescript-operations-4.2.3.tgz",
+            "integrity": "sha512-6z7avSSOr03l5SyKbeDs7MzRyGwnQFSCqQm8Om5wIuoIgXVu2gXRmcJAY/I7SLdAy9xbF4Sho7XNqieFM2CAFQ==",
             "dev": true,
             "dependencies": {
-                "@graphql-codegen/plugin-helpers": "^5.0.0",
-                "@graphql-codegen/typescript": "^4.0.1",
-                "@graphql-codegen/visitor-plugin-common": "4.0.1",
+                "@graphql-codegen/plugin-helpers": "^5.0.4",
+                "@graphql-codegen/typescript": "^4.0.9",
+                "@graphql-codegen/visitor-plugin-common": "5.3.1",
                 "auto-bind": "~4.0.0",
-                "tslib": "~2.5.0"
+                "tslib": "~2.6.0"
             },
             "peerDependencies": {
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
         },
-        "node_modules/@graphql-codegen/typescript-operations/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
+        "node_modules/@graphql-codegen/typescript-operations/node_modules/@graphql-codegen/typescript": {
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/typescript/-/typescript-4.0.9.tgz",
+            "integrity": "sha512-0O35DMR4d/ctuHL1Zo6mRUUzp0BoszKfeWsa6sCm/g70+S98+hEfTwZNDkQHylLxapiyjssF9uw/F+sXqejqLw==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^5.0.4",
+                "@graphql-codegen/schema-ast": "^4.0.2",
+                "@graphql-codegen/visitor-plugin-common": "5.3.1",
+                "auto-bind": "~4.0.0",
+                "tslib": "~2.6.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
         },
-        "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-            "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-            "dev": true
-        },
-        "node_modules/@graphql-codegen/visitor-plugin-common": {
+        "node_modules/@graphql-codegen/typescript/node_modules/@graphql-codegen/visitor-plugin-common": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-4.0.1.tgz",
             "integrity": "sha512-Bi/1z0nHg4QMsAqAJhds+ForyLtk7A3HQOlkrZNm3xEkY7lcBzPtiOTLBtvziwopBsXUxqeSwVjOOFPLS5Yw1Q==",
@@ -1352,20 +1277,41 @@
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
             }
         },
-        "node_modules/@graphql-codegen/visitor-plugin-common/node_modules/tslib": {
+        "node_modules/@graphql-codegen/typescript/node_modules/tslib": {
             "version": "2.5.3",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
             "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
             "dev": true
         },
+        "node_modules/@graphql-codegen/visitor-plugin-common": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@graphql-codegen/visitor-plugin-common/-/visitor-plugin-common-5.3.1.tgz",
+            "integrity": "sha512-MktoBdNZhSmugiDjmFl1z6rEUUaqyxtFJYWnDilE7onkPgyw//O0M+TuPBJPBWdyV6J2ond0Hdqtq+rkghgSIQ==",
+            "dev": true,
+            "dependencies": {
+                "@graphql-codegen/plugin-helpers": "^5.0.4",
+                "@graphql-tools/optimize": "^2.0.0",
+                "@graphql-tools/relay-operation-optimizer": "^7.0.0",
+                "@graphql-tools/utils": "^10.0.0",
+                "auto-bind": "~4.0.0",
+                "change-case-all": "1.0.15",
+                "dependency-graph": "^0.11.0",
+                "graphql-tag": "^2.11.0",
+                "parse-filepath": "^1.0.2",
+                "tslib": "~2.6.0"
+            },
+            "peerDependencies": {
+                "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
+            }
+        },
         "node_modules/@graphql-tools/apollo-engine-loader": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.0.tgz",
-            "integrity": "sha512-axQTbN5+Yxs1rJ6cWQBOfw3AEeC+fvIuZSfJLPLLvFJLj4pUm9fhxey/g6oQZAAQJqKPfw+tLDUQvnfvRK8Kmg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/apollo-engine-loader/-/apollo-engine-loader-8.0.1.tgz",
+            "integrity": "sha512-NaPeVjtrfbPXcl+MLQCJLWtqe2/E4bbAqcauEOQ+3sizw1Fc2CNmhHRF8a6W4D0ekvTRRXAMptXYgA2uConbrA==",
             "dev": true,
             "dependencies": {
                 "@ardatan/sync-fetch": "^0.0.1",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "@whatwg-node/fetch": "^0.9.0",
                 "tslib": "^2.4.0"
             },
@@ -1386,28 +1332,28 @@
             }
         },
         "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/fetch": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
-            "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+            "version": "0.9.18",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+            "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
             "dev": true,
             "dependencies": {
-                "@whatwg-node/node-fetch": "^0.4.8",
-                "urlpattern-polyfill": "^9.0.0"
+                "@whatwg-node/node-fetch": "^0.5.7",
+                "urlpattern-polyfill": "^10.0.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@graphql-tools/apollo-engine-loader/node_modules/@whatwg-node/node-fetch": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.14.tgz",
-            "integrity": "sha512-ii/eZz2PcjLGj9D6WfsmfzlTzZV1Kz6MxYpq2Vc5P21J8vkKfENWC9B2ISsFCKovxElLukIwPg8HTrHFsLNflg==",
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+            "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
             "dev": true,
             "dependencies": {
+                "@kamilkisiela/fast-url-parser": "^1.1.4",
                 "@whatwg-node/events": "^0.1.0",
                 "busboy": "^1.6.0",
                 "fast-querystring": "^1.1.1",
-                "fast-url-parser": "^1.1.3",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -1415,18 +1361,18 @@
             }
         },
         "node_modules/@graphql-tools/apollo-engine-loader/node_modules/urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "node_modules/@graphql-tools/batch-execute": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.2.tgz",
-            "integrity": "sha512-Y2uwdZI6ZnatopD/SYfZ1eGuQFI7OU2KGZ2/B/7G9ISmgMl5K+ZZWz/PfIEXeiHirIDhyk54s4uka5rj2xwKqQ==",
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/batch-execute/-/batch-execute-9.0.4.tgz",
+            "integrity": "sha512-kkebDLXgDrep5Y0gK1RN3DMUlLqNhg60OAz0lTCqrYeja6DshxLtLkj+zV4mVbBA4mQOEoBmw6g1LZs3dA84/w==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.5",
+                "@graphql-tools/utils": "^10.0.13",
                 "dataloader": "^2.2.2",
                 "tslib": "^2.4.0",
                 "value-or-promise": "^1.0.12"
@@ -1439,13 +1385,13 @@
             }
         },
         "node_modules/@graphql-tools/code-file-loader": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.0.2.tgz",
-            "integrity": "sha512-AKNpkElUL2cWocYpC4DzNEpo6qJw8Lp+L3bKQ/mIfmbsQxgLz5uve6zHBMhDaFPdlwfIox41N3iUSvi77t9e8A==",
+            "version": "8.1.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/code-file-loader/-/code-file-loader-8.1.2.tgz",
+            "integrity": "sha512-GrLzwl1QV2PT4X4TEEfuTmZYzIZHLqoTGBjczdUzSqgCCcqwWzLB3qrJxFQfI8e5s1qZ1bhpsO9NoMn7tvpmyA==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/graphql-tag-pluck": "8.0.2",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/graphql-tag-pluck": "8.3.1",
+                "@graphql-tools/utils": "^10.0.13",
                 "globby": "^11.0.3",
                 "tslib": "^2.4.0",
                 "unixify": "^1.0.0"
@@ -1458,15 +1404,15 @@
             }
         },
         "node_modules/@graphql-tools/delegate": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.2.tgz",
-            "integrity": "sha512-ZU7VnR2xFgHrGnsuw6+nRJkcvSucn7w5ooxb/lTKlVfrNJfTwJevNcNKMnbtPUSajG3+CaFym/nU6v44GXCmNw==",
+            "version": "10.0.13",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-10.0.13.tgz",
+            "integrity": "sha512-9l7cwrHQFbvR6zhZOKYABa3ffqgyV51gNglammupXhptE3Z94p6A6hP0hLw7GHErkm6MiQINl3VBVpFJDlrZuQ==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/batch-execute": "^9.0.1",
-                "@graphql-tools/executor": "^1.0.0",
-                "@graphql-tools/schema": "^10.0.0",
-                "@graphql-tools/utils": "^10.0.5",
+                "@graphql-tools/batch-execute": "^9.0.4",
+                "@graphql-tools/executor": "^1.2.8",
+                "@graphql-tools/schema": "^10.0.4",
+                "@graphql-tools/utils": "^10.2.3",
                 "dataloader": "^2.2.2",
                 "tslib": "^2.5.0"
             },
@@ -1478,9 +1424,9 @@
             }
         },
         "node_modules/@graphql-tools/documents": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/documents/-/documents-1.0.0.tgz",
-            "integrity": "sha512-rHGjX1vg/nZ2DKqRGfDPNC55CWZBMldEVcH+91BThRa6JeT80NqXknffLLEZLRUxyikCfkwMsk6xR3UNMqG0Rg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/documents/-/documents-1.0.1.tgz",
+            "integrity": "sha512-aweoMH15wNJ8g7b2r4C4WRuJxZ0ca8HtNO54rkye/3duxTkW4fGBEutCx03jCIr5+a1l+4vFJNP859QnAVBVCA==",
             "dev": true,
             "dependencies": {
                 "lodash.sortby": "^4.7.0",
@@ -1494,12 +1440,12 @@
             }
         },
         "node_modules/@graphql-tools/executor": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.0.tgz",
-            "integrity": "sha512-SKlIcMA71Dha5JnEWlw4XxcaJ+YupuXg0QCZgl2TOLFz4SkGCwU/geAsJvUJFwK2RbVLpQv/UMq67lOaBuwDtg==",
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor/-/executor-1.2.8.tgz",
+            "integrity": "sha512-0qZs/iuRiYRir7bBkA7oN+21wwmSMPQuFK8WcAcxUYJZRhvnlrJ8Nid++PN4OCzTgHPV70GNFyXOajseVCCffA==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.2.3",
                 "@graphql-typed-document-node/core": "3.2.0",
                 "@repeaterjs/repeater": "^3.0.4",
                 "tslib": "^2.4.0",
@@ -1513,12 +1459,12 @@
             }
         },
         "node_modules/@graphql-tools/executor-graphql-ws": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.1.0.tgz",
-            "integrity": "sha512-yM67SzwE8rYRpm4z4AuGtABlOp9mXXVy6sxXnTJRoYIdZrmDbKVfIY+CpZUJCqS0FX3xf2+GoHlsj7Qswaxgcg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-graphql-ws/-/executor-graphql-ws-1.1.2.tgz",
+            "integrity": "sha512-+9ZK0rychTH1LUv4iZqJ4ESbmULJMTsv3XlFooPUngpxZkk00q6LqHKJRrsLErmQrVaC7cwQCaRBJa0teK17Lg==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.2",
+                "@graphql-tools/utils": "^10.0.13",
                 "@types/ws": "^8.0.0",
                 "graphql-ws": "^5.14.0",
                 "isomorphic-ws": "^5.0.0",
@@ -1533,12 +1479,12 @@
             }
         },
         "node_modules/@graphql-tools/executor-http": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.2.tgz",
-            "integrity": "sha512-JKTB4E3kdQM2/1NEcyrVPyQ8057ZVthCV5dFJiKktqY9IdmF00M8gupFcW3jlbM/Udn78ickeUBsUzA3EouqpA==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-http/-/executor-http-1.0.9.tgz",
+            "integrity": "sha512-+NXaZd2MWbbrWHqU4EhXcrDbogeiCDmEbrAN+rMn4Nu2okDjn2MTFDbTIab87oEubQCH4Te1wDkWPKrzXup7+Q==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.2",
+                "@graphql-tools/utils": "^10.0.13",
                 "@repeaterjs/repeater": "^3.0.4",
                 "@whatwg-node/fetch": "^0.9.0",
                 "extract-files": "^11.0.0",
@@ -1563,28 +1509,28 @@
             }
         },
         "node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/fetch": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
-            "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+            "version": "0.9.18",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+            "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
             "dev": true,
             "dependencies": {
-                "@whatwg-node/node-fetch": "^0.4.8",
-                "urlpattern-polyfill": "^9.0.0"
+                "@whatwg-node/node-fetch": "^0.5.7",
+                "urlpattern-polyfill": "^10.0.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@graphql-tools/executor-http/node_modules/@whatwg-node/node-fetch": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.14.tgz",
-            "integrity": "sha512-ii/eZz2PcjLGj9D6WfsmfzlTzZV1Kz6MxYpq2Vc5P21J8vkKfENWC9B2ISsFCKovxElLukIwPg8HTrHFsLNflg==",
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+            "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
             "dev": true,
             "dependencies": {
+                "@kamilkisiela/fast-url-parser": "^1.1.4",
                 "@whatwg-node/events": "^0.1.0",
                 "busboy": "^1.6.0",
                 "fast-querystring": "^1.1.1",
-                "fast-url-parser": "^1.1.3",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -1592,22 +1538,22 @@
             }
         },
         "node_modules/@graphql-tools/executor-http/node_modules/urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "node_modules/@graphql-tools/executor-legacy-ws": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.1.tgz",
-            "integrity": "sha512-PQrTJ+ncHMEQspBARc2lhwiQFfRAX/z/CsOdZTFjIljOHgRWGAA1DAx7pEN0j6PflbLCfZ3NensNq2jCBwF46w==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/executor-legacy-ws/-/executor-legacy-ws-1.0.6.tgz",
+            "integrity": "sha512-lDSxz9VyyquOrvSuCCnld3256Hmd+QI2lkmkEv7d4mdzkxkK4ddAWW1geQiWrQvWmdsmcnGGlZ7gDGbhEExwqg==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "@types/ws": "^8.0.0",
-                "isomorphic-ws": "5.0.0",
+                "isomorphic-ws": "^5.0.0",
                 "tslib": "^2.4.0",
-                "ws": "8.13.0"
+                "ws": "^8.15.0"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -1617,13 +1563,13 @@
             }
         },
         "node_modules/@graphql-tools/git-loader": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.2.tgz",
-            "integrity": "sha512-AuCB0nlPvsHh8u42zRZdlD/ZMaWP9A44yAkQUVCZir1E/LG63fsZ9svTWJ+CbusW3Hd0ZP9qpxEhlHxnd4Tlsg==",
+            "version": "8.0.6",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/git-loader/-/git-loader-8.0.6.tgz",
+            "integrity": "sha512-FQFO4H5wHAmHVyuUQrjvPE8re3qJXt50TWHuzrK3dEaief7JosmlnkLMDMbMBwtwITz9u1Wpl6doPhT2GwKtlw==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/graphql-tag-pluck": "8.0.2",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/graphql-tag-pluck": "8.3.1",
+                "@graphql-tools/utils": "^10.0.13",
                 "is-glob": "4.0.3",
                 "micromatch": "^4.0.4",
                 "tslib": "^2.4.0",
@@ -1637,15 +1583,15 @@
             }
         },
         "node_modules/@graphql-tools/github-loader": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.0.tgz",
-            "integrity": "sha512-VuroArWKcG4yaOWzV0r19ElVIV6iH6UKDQn1MXemND0xu5TzrFme0kf3U9o0YwNo0kUYEk9CyFM0BYg4he17FA==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/github-loader/-/github-loader-8.0.1.tgz",
+            "integrity": "sha512-W4dFLQJ5GtKGltvh/u1apWRFKBQOsDzFxO9cJkOYZj1VzHCpRF43uLST4VbCfWve+AwBqOuKr7YgkHoxpRMkcg==",
             "dev": true,
             "dependencies": {
                 "@ardatan/sync-fetch": "^0.0.1",
-                "@graphql-tools/executor-http": "^1.0.0",
+                "@graphql-tools/executor-http": "^1.0.9",
                 "@graphql-tools/graphql-tag-pluck": "^8.0.0",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "@whatwg-node/fetch": "^0.9.0",
                 "tslib": "^2.4.0",
                 "value-or-promise": "^1.0.12"
@@ -1667,28 +1613,28 @@
             }
         },
         "node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/fetch": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
-            "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+            "version": "0.9.18",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+            "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
             "dev": true,
             "dependencies": {
-                "@whatwg-node/node-fetch": "^0.4.8",
-                "urlpattern-polyfill": "^9.0.0"
+                "@whatwg-node/node-fetch": "^0.5.7",
+                "urlpattern-polyfill": "^10.0.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@graphql-tools/github-loader/node_modules/@whatwg-node/node-fetch": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.14.tgz",
-            "integrity": "sha512-ii/eZz2PcjLGj9D6WfsmfzlTzZV1Kz6MxYpq2Vc5P21J8vkKfENWC9B2ISsFCKovxElLukIwPg8HTrHFsLNflg==",
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+            "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
             "dev": true,
             "dependencies": {
+                "@kamilkisiela/fast-url-parser": "^1.1.4",
                 "@whatwg-node/events": "^0.1.0",
                 "busboy": "^1.6.0",
                 "fast-querystring": "^1.1.1",
-                "fast-url-parser": "^1.1.3",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -1696,19 +1642,19 @@
             }
         },
         "node_modules/@graphql-tools/github-loader/node_modules/urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "node_modules/@graphql-tools/graphql-file-loader": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.0.tgz",
-            "integrity": "sha512-wRXj9Z1IFL3+zJG1HWEY0S4TXal7+s1vVhbZva96MSp0kbb/3JBF7j0cnJ44Eq0ClccMgGCDFqPFXty4JlpaPg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-file-loader/-/graphql-file-loader-8.0.1.tgz",
+            "integrity": "sha512-7gswMqWBabTSmqbaNyWSmRRpStWlcCkBc73E6NZNlh4YNuiyKOwbvSkOUYFOqFMfEL+cFsXgAvr87Vz4XrYSbA==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/import": "7.0.0",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/import": "7.0.1",
+                "@graphql-tools/utils": "^10.0.13",
                 "globby": "^11.0.3",
                 "tslib": "^2.4.0",
                 "unixify": "^1.0.0"
@@ -1721,9 +1667,9 @@
             }
         },
         "node_modules/@graphql-tools/graphql-tag-pluck": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.0.2.tgz",
-            "integrity": "sha512-U6fE4yEHxuk/nqmPixHpw1WhqdS6aYuaV60m1bEmUmGJNbpAhaMBy01JncpvpF15yZR5LZ0UjkHg+A3Lhoc8YQ==",
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-8.3.1.tgz",
+            "integrity": "sha512-ujits9tMqtWQQq4FI4+qnVPpJvSEn7ogKtyN/gfNT+ErIn6z1e4gyVGQpTK5sgAUXq1lW4gU/5fkFFC5/sL2rQ==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.22.9",
@@ -1731,7 +1677,7 @@
                 "@babel/plugin-syntax-import-assertions": "^7.20.0",
                 "@babel/traverse": "^7.16.8",
                 "@babel/types": "^7.16.8",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "tslib": "^2.4.0"
             },
             "engines": {
@@ -1742,12 +1688,12 @@
             }
         },
         "node_modules/@graphql-tools/import": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.0.tgz",
-            "integrity": "sha512-NVZiTO8o1GZs6OXzNfjB+5CtQtqsZZpQOq+Uu0w57kdUkT4RlQKlwhT8T81arEsbV55KpzkpFsOZP7J1wdmhBw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-7.0.1.tgz",
+            "integrity": "sha512-935uAjAS8UAeXThqHfYVr4HEAp6nHJ2sximZKO1RzUTq5WoALMAhhGARl0+ecm6X+cqNUwIChJbjtaa6P/ML0w==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "resolve-from": "5.0.0",
                 "tslib": "^2.4.0"
             },
@@ -1759,12 +1705,12 @@
             }
         },
         "node_modules/@graphql-tools/json-file-loader": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.0.tgz",
-            "integrity": "sha512-ki6EF/mobBWJjAAC84xNrFMhNfnUFD6Y0rQMGXekrUgY0NdeYXHU0ZUgHzC9O5+55FslqUmAUHABePDHTyZsLg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/json-file-loader/-/json-file-loader-8.0.1.tgz",
+            "integrity": "sha512-lAy2VqxDAHjVyqeJonCP6TUemrpYdDuKt25a10X6zY2Yn3iFYGnuIDQ64cv3ytyGY6KPyPB+Kp+ZfOkNDG3FQA==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "globby": "^11.0.3",
                 "tslib": "^2.4.0",
                 "unixify": "^1.0.0"
@@ -1777,13 +1723,13 @@
             }
         },
         "node_modules/@graphql-tools/load": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.0.tgz",
-            "integrity": "sha512-Cy874bQJH0FP2Az7ELPM49iDzOljQmK1PPH6IuxsWzLSTxwTqd8dXA09dcVZrI7/LsN26heTY2R8q2aiiv0GxQ==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/load/-/load-8.0.2.tgz",
+            "integrity": "sha512-S+E/cmyVmJ3CuCNfDuNF2EyovTwdWfQScXv/2gmvJOti2rGD8jTt9GYVzXaxhblLivQR9sBUCNZu/w7j7aXUCA==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/schema": "^10.0.0",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/schema": "^10.0.3",
+                "@graphql-tools/utils": "^10.0.13",
                 "p-limit": "3.1.0",
                 "tslib": "^2.4.0"
             },
@@ -1795,12 +1741,12 @@
             }
         },
         "node_modules/@graphql-tools/merge": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.0.tgz",
-            "integrity": "sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==",
+            "version": "9.0.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/merge/-/merge-9.0.4.tgz",
+            "integrity": "sha512-MivbDLUQ+4Q8G/Hp/9V72hbn810IJDEZQ57F01sHnlrrijyadibfVhaQfW/pNH+9T/l8ySZpaR/DpL5i+ruZ+g==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "tslib": "^2.4.0"
             },
             "engines": {
@@ -1826,15 +1772,14 @@
             }
         },
         "node_modules/@graphql-tools/prisma-loader": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.1.tgz",
-            "integrity": "sha512-bl6e5sAYe35Z6fEbgKXNrqRhXlCJYeWKBkarohgYA338/SD9eEhXtg3Cedj7fut3WyRLoQFpHzfiwxKs7XrgXg==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/prisma-loader/-/prisma-loader-8.0.4.tgz",
+            "integrity": "sha512-hqKPlw8bOu/GRqtYr0+dINAI13HinTVYBDqhwGAPIFmLr5s+qKskzgCiwbsckdrb5LWVFmVZc+UXn80OGiyBzg==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/url-loader": "^8.0.0",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/url-loader": "^8.0.2",
+                "@graphql-tools/utils": "^10.0.13",
                 "@types/js-yaml": "^4.0.0",
-                "@types/json-stable-stringify": "^1.0.32",
                 "@whatwg-node/fetch": "^0.9.0",
                 "chalk": "^4.1.0",
                 "debug": "^4.3.1",
@@ -1842,9 +1787,8 @@
                 "graphql-request": "^6.0.0",
                 "http-proxy-agent": "^7.0.0",
                 "https-proxy-agent": "^7.0.0",
-                "jose": "^4.11.4",
+                "jose": "^5.0.0",
                 "js-yaml": "^4.0.0",
-                "json-stable-stringify": "^1.0.1",
                 "lodash": "^4.17.20",
                 "scuid": "^1.1.0",
                 "tslib": "^2.4.0",
@@ -1867,28 +1811,28 @@
             }
         },
         "node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/fetch": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
-            "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+            "version": "0.9.18",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+            "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
             "dev": true,
             "dependencies": {
-                "@whatwg-node/node-fetch": "^0.4.8",
-                "urlpattern-polyfill": "^9.0.0"
+                "@whatwg-node/node-fetch": "^0.5.7",
+                "urlpattern-polyfill": "^10.0.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@graphql-tools/prisma-loader/node_modules/@whatwg-node/node-fetch": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.14.tgz",
-            "integrity": "sha512-ii/eZz2PcjLGj9D6WfsmfzlTzZV1Kz6MxYpq2Vc5P21J8vkKfENWC9B2ISsFCKovxElLukIwPg8HTrHFsLNflg==",
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+            "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
             "dev": true,
             "dependencies": {
+                "@kamilkisiela/fast-url-parser": "^1.1.4",
                 "@whatwg-node/events": "^0.1.0",
                 "busboy": "^1.6.0",
                 "fast-querystring": "^1.1.1",
-                "fast-url-parser": "^1.1.3",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -1896,19 +1840,19 @@
             }
         },
         "node_modules/@graphql-tools/prisma-loader/node_modules/urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "node_modules/@graphql-tools/relay-operation-optimizer": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.0.tgz",
-            "integrity": "sha512-UNlJi5y3JylhVWU4MBpL0Hun4Q7IoJwv9xYtmAz+CgRa066szzY7dcuPfxrA7cIGgG/Q6TVsKsYaiF4OHPs1Fw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-7.0.1.tgz",
+            "integrity": "sha512-y0ZrQ/iyqWZlsS/xrJfSir3TbVYJTYmMOu4TaSz6F4FRDTQ3ie43BlKkhf04rC28pnUOS4BO9pDcAo1D30l5+A==",
             "dev": true,
             "dependencies": {
                 "@ardatan/relay-compiler": "12.0.0",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/utils": "^10.0.13",
                 "tslib": "^2.4.0"
             },
             "engines": {
@@ -1919,13 +1863,13 @@
             }
         },
         "node_modules/@graphql-tools/schema": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.0.tgz",
-            "integrity": "sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==",
+            "version": "10.0.4",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/schema/-/schema-10.0.4.tgz",
+            "integrity": "sha512-HuIwqbKxPaJujox25Ra4qwz0uQzlpsaBOzO6CVfzB/MemZdd+Gib8AIvfhQArK0YIN40aDran/yi+E5Xf0mQww==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/merge": "^9.0.0",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/merge": "^9.0.3",
+                "@graphql-tools/utils": "^10.2.1",
                 "tslib": "^2.4.0",
                 "value-or-promise": "^1.0.12"
             },
@@ -1937,18 +1881,18 @@
             }
         },
         "node_modules/@graphql-tools/url-loader": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.0.tgz",
-            "integrity": "sha512-rPc9oDzMnycvz+X+wrN3PLrhMBQkG4+sd8EzaFN6dypcssiefgWKToXtRKI8HHK68n2xEq1PyrOpkjHFJB+GwA==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-8.0.2.tgz",
+            "integrity": "sha512-1dKp2K8UuFn7DFo1qX5c1cyazQv2h2ICwA9esHblEqCYrgf69Nk8N7SODmsfWg94OEaI74IqMoM12t7eIGwFzQ==",
             "dev": true,
             "dependencies": {
                 "@ardatan/sync-fetch": "^0.0.1",
-                "@graphql-tools/delegate": "^10.0.0",
-                "@graphql-tools/executor-graphql-ws": "^1.0.0",
-                "@graphql-tools/executor-http": "^1.0.0",
-                "@graphql-tools/executor-legacy-ws": "^1.0.0",
-                "@graphql-tools/utils": "^10.0.0",
-                "@graphql-tools/wrap": "^10.0.0",
+                "@graphql-tools/delegate": "^10.0.4",
+                "@graphql-tools/executor-graphql-ws": "^1.1.2",
+                "@graphql-tools/executor-http": "^1.0.9",
+                "@graphql-tools/executor-legacy-ws": "^1.0.6",
+                "@graphql-tools/utils": "^10.0.13",
+                "@graphql-tools/wrap": "^10.0.2",
                 "@types/ws": "^8.0.0",
                 "@whatwg-node/fetch": "^0.9.0",
                 "isomorphic-ws": "^5.0.0",
@@ -1973,28 +1917,28 @@
             }
         },
         "node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/fetch": {
-            "version": "0.9.9",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.9.tgz",
-            "integrity": "sha512-OTVoDm039CNyAWSRc2WBimMl/N9J4Fk2le21Xzcf+3OiWPNNSIbMnpWKBUyraPh2d9SAEgoBdQxTfVNihXgiUw==",
+            "version": "0.9.18",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.18.tgz",
+            "integrity": "sha512-hqoz6StCW+AjV/3N+vg0s1ah82ptdVUb9nH2ttj3UbySOXUvytWw2yqy8c1cKzyRk6mDD00G47qS3fZI9/gMjg==",
             "dev": true,
             "dependencies": {
-                "@whatwg-node/node-fetch": "^0.4.8",
-                "urlpattern-polyfill": "^9.0.0"
+                "@whatwg-node/node-fetch": "^0.5.7",
+                "urlpattern-polyfill": "^10.0.0"
             },
             "engines": {
                 "node": ">=16.0.0"
             }
         },
         "node_modules/@graphql-tools/url-loader/node_modules/@whatwg-node/node-fetch": {
-            "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.4.14.tgz",
-            "integrity": "sha512-ii/eZz2PcjLGj9D6WfsmfzlTzZV1Kz6MxYpq2Vc5P21J8vkKfENWC9B2ISsFCKovxElLukIwPg8HTrHFsLNflg==",
+            "version": "0.5.11",
+            "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.11.tgz",
+            "integrity": "sha512-LS8tSomZa3YHnntpWt3PP43iFEEl6YeIsvDakczHBKlay5LdkXFr8w7v8H6akpG5nRrzydyB0k1iE2eoL6aKIQ==",
             "dev": true,
             "dependencies": {
+                "@kamilkisiela/fast-url-parser": "^1.1.4",
                 "@whatwg-node/events": "^0.1.0",
                 "busboy": "^1.6.0",
                 "fast-querystring": "^1.1.1",
-                "fast-url-parser": "^1.1.3",
                 "tslib": "^2.3.1"
             },
             "engines": {
@@ -2002,18 +1946,19 @@
             }
         },
         "node_modules/@graphql-tools/url-loader/node_modules/urlpattern-polyfill": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz",
-            "integrity": "sha512-WHN8KDQblxd32odxeIgo83rdVDE2bvdkb86it7bMhYZwWKJz0+O0RK/eZiHYnM+zgt/U7hAHOlCQGfjjvSkw2g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
             "dev": true
         },
         "node_modules/@graphql-tools/utils": {
-            "version": "10.0.5",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.0.5.tgz",
-            "integrity": "sha512-ZTioQqg9z9eCG3j+KDy54k1gp6wRIsLqkx5yi163KVvXVkfjsrdErCyZjrEug21QnKE9piP4tyxMpMMOT1RuRw==",
+            "version": "10.2.3",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-10.2.3.tgz",
+            "integrity": "sha512-j7x0sO0VtWVhD3FubyY42abx+g61/at5W5Y3DSOckPkBo7yVjkcnAsXoB4jiUnznhGme/o+uX5VgA8HrjyR5ZQ==",
             "dev": true,
             "dependencies": {
                 "@graphql-typed-document-node/core": "^3.1.1",
+                "cross-inspect": "1.0.0",
                 "dset": "^3.1.2",
                 "tslib": "^2.4.0"
             },
@@ -2025,14 +1970,14 @@
             }
         },
         "node_modules/@graphql-tools/wrap": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.0.tgz",
-            "integrity": "sha512-HDOeUUh6UhpiH0WPJUQl44ODt1x5pnMUbOJZ7GjTdGQ7LK0AgVt3ftaAQ9duxLkiAtYJmu5YkULirfZGj4HzDg==",
+            "version": "10.0.5",
+            "resolved": "https://registry.npmjs.org/@graphql-tools/wrap/-/wrap-10.0.5.tgz",
+            "integrity": "sha512-Cbr5aYjr3HkwdPvetZp1cpDWTGdD1Owgsb3z/ClzhmrboiK86EnQDxDvOJiQkDCPWE9lNBwj8Y4HfxroY0D9DQ==",
             "dev": true,
             "dependencies": {
-                "@graphql-tools/delegate": "^10.0.0",
-                "@graphql-tools/schema": "^10.0.0",
-                "@graphql-tools/utils": "^10.0.0",
+                "@graphql-tools/delegate": "^10.0.4",
+                "@graphql-tools/schema": "^10.0.3",
+                "@graphql-tools/utils": "^10.1.1",
                 "tslib": "^2.4.0",
                 "value-or-promise": "^1.0.12"
             },
@@ -2053,32 +1998,32 @@
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -2091,14 +2036,20 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@kamilkisiela/fast-url-parser": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
+            "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
+            "dev": true
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2136,14 +2087,14 @@
             }
         },
         "node_modules/@peculiar/asn1-schema": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.6.tgz",
-            "integrity": "sha512-izNRxPoaeJeg/AyH8hER6s+H7p4itk+03QCa4sbxI3lNdseQYCuxzgsuNK8bTXChtLTjpJz6NmXKA73qLa3rCA==",
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.8.tgz",
+            "integrity": "sha512-ULB1XqHKx1WBU/tTFIA+uARuRoBVZ4pNdOA878RDrRbBfBGcSzi5HBkdScC6ZbHn8z7L8gmKCgPC1LHRrP46tA==",
             "dev": true,
             "dependencies": {
                 "asn1js": "^3.0.5",
-                "pvtsutils": "^1.3.2",
-                "tslib": "^2.4.0"
+                "pvtsutils": "^1.3.5",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/@peculiar/json-schema": {
@@ -2159,49 +2110,46 @@
             }
         },
         "node_modules/@peculiar/webcrypto": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.4.3.tgz",
-            "integrity": "sha512-VtaY4spKTdN5LjJ04im/d/joXuvLbQdgy5Z4DXF4MFZhQ+MTrejbNMkfZBp1Bs3O5+bFqnJgyGdPuZQflvIa5A==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
+            "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
             "dev": true,
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
                 "@peculiar/json-schema": "^1.1.12",
-                "pvtsutils": "^1.3.2",
-                "tslib": "^2.5.0",
-                "webcrypto-core": "^1.7.7"
+                "pvtsutils": "^1.3.5",
+                "tslib": "^2.6.2",
+                "webcrypto-core": "^1.8.0"
             },
             "engines": {
                 "node": ">=10.12.0"
             }
         },
         "node_modules/@repeaterjs/repeater": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
-            "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+            "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
             "dev": true
         },
         "node_modules/@types/js-yaml": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
-            "integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
-            "dev": true
-        },
-        "node_modules/@types/json-stable-stringify": {
-            "version": "1.0.34",
-            "resolved": "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz",
-            "integrity": "sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+            "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "20.5.4",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.4.tgz",
-            "integrity": "sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==",
-            "dev": true
+            "version": "20.14.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.9.tgz",
+            "integrity": "sha512-06OCtnTXtWOZBJlRApleWndH4JsRVs1pDCc8dLSQp+7PpUpX3ePdHyeNSFTeSe7FtKyQkrlPvHwJOW3SLd8Oyg==",
+            "dev": true,
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/ws": {
-            "version": "8.5.5",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-            "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+            "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -2240,9 +2188,9 @@
             }
         },
         "node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.3.4"
@@ -2451,21 +2399,21 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.10",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
-            "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
+            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
             "dev": true,
             "funding": [
                 {
@@ -2482,10 +2430,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001517",
-                "electron-to-chromium": "^1.4.477",
-                "node-releases": "^2.0.13",
-                "update-browserslist-db": "^1.0.11"
+                "caniuse-lite": "^1.0.30001629",
+                "electron-to-chromium": "^1.4.796",
+                "node-releases": "^2.0.14",
+                "update-browserslist-db": "^1.0.16"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2568,9 +2516,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001522",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001522.tgz",
-            "integrity": "sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==",
+            "version": "1.0.30001640",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz",
+            "integrity": "sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==",
             "dev": true,
             "funding": [
                 {
@@ -2680,9 +2628,9 @@
             }
         },
         "node_modules/cli-spinners": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
-            "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+            "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -2807,20 +2755,20 @@
             }
         },
         "node_modules/convert-source-map": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-            "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
         },
         "node_modules/cosmiconfig": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-            "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+            "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
             "dev": true,
             "dependencies": {
-                "import-fresh": "^3.2.1",
+                "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.0.0",
+                "parse-json": "^5.2.0",
                 "path-type": "^4.0.0"
             },
             "engines": {
@@ -2828,6 +2776,14 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/cross-fetch": {
@@ -2837,6 +2793,18 @@
             "dev": true,
             "dependencies": {
                 "node-fetch": "^2.6.12"
+            }
+        },
+        "node_modules/cross-inspect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cross-inspect/-/cross-inspect-1.0.0.tgz",
+            "integrity": "sha512-4PFfn4b5ZN6FMNGSZlyb7wUhuN8wvj8t/VQHZdM4JsDcruGJ8L2kf9zao98QIrBPFCpdk27qst/AGTl7pL3ypQ==",
+            "dev": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
             }
         },
         "node_modules/dataloader": {
@@ -2852,9 +2820,9 @@
             "dev": true
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+            "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
             "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
@@ -2930,30 +2898,30 @@
             }
         },
         "node_modules/dotenv": {
-            "version": "16.3.1",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-            "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+            "version": "16.4.5",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+            "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
             "dev": true,
             "engines": {
                 "node": ">=12"
             },
             "funding": {
-                "url": "https://github.com/motdotla/dotenv?sponsor=1"
+                "url": "https://dotenvx.com"
             }
         },
         "node_modules/dset": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.2.tgz",
-            "integrity": "sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
+            "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
             "dev": true,
             "engines": {
                 "node": ">=4"
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.500",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.500.tgz",
-            "integrity": "sha512-P38NO8eOuWOKY1sQk5yE0crNtrjgjJj6r3NrbIKtG18KzCHmHE2Bt+aQA7/y0w3uYsHWxDa6icOohzjLJ4vJ4A==",
+            "version": "1.4.816",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.816.tgz",
+            "integrity": "sha512-EKH5X5oqC6hLmiS7/vYtZHZFTNdhsYG5NVPRN6Yn0kQHNBlT59+xSM8HBy66P5fxWpKgZbPqb+diC64ng295Jw==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -2972,9 +2940,9 @@
             }
         },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -3022,9 +2990,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -3056,9 +3024,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
             "dependencies": {
                 "reusify": "^1.0.4"
@@ -3110,9 +3078,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -3251,6 +3219,7 @@
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
             "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "deprecated": "Glob versions prior to v9 are no longer supported",
             "dev": true,
             "dependencies": {
                 "fs.realpath": "^1.0.0",
@@ -3309,18 +3278,18 @@
             }
         },
         "node_modules/graphql": {
-            "version": "16.8.0",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.0.tgz",
-            "integrity": "sha512-0oKGaR+y3qcS5mCu1vb7KG+a89vjn06C7Ihq/dDl3jA+A8B3TKomvi3CiEcVLJQGalbu8F52LxkOym7U5sSfbg==",
+            "version": "16.9.0",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
+            "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
         },
         "node_modules/graphql-config": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.2.tgz",
-            "integrity": "sha512-7TPxOrlbiG0JplSZYCyxn2XQtqVhXomEjXUmWJVSS5ET1nPhOJSsIb/WTwqWhcYX6G0RlHXSj9PLtGTKmxLNGg==",
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/graphql-config/-/graphql-config-5.0.3.tgz",
+            "integrity": "sha512-BNGZaoxIBkv9yy6Y7omvsaBUHOzfFcII3UN++tpH8MGOKFPFkCPZuwx09ggANMt8FgyWP1Od8SWPmrUEZca4NQ==",
             "dev": true,
             "dependencies": {
                 "@graphql-tools/graphql-file-loader": "^8.0.0",
@@ -3389,10 +3358,13 @@
             }
         },
         "node_modules/graphql-ws": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.14.0.tgz",
-            "integrity": "sha512-itrUTQZP/TgswR4GSSYuwWUzrE/w5GhbwM2GX3ic2U7aw33jgEsayfIlvaj7/GcIvZgNMzsPTrE5hqPuFUiE5g==",
+            "version": "5.16.0",
+            "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.0.tgz",
+            "integrity": "sha512-Ju2RCU2dQMgSKtArPbEtsK5gNLnsQyTNIo/T7cZNp96niC1x0KdJNZV0TIoilceBPQwfb5itrGl8pkFeOUMl4A==",
             "dev": true,
+            "workspaces": [
+                "website"
+            ],
             "engines": {
                 "node": ">=10"
             },
@@ -3420,9 +3392,9 @@
             }
         },
         "node_modules/http-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.1.0",
@@ -3433,9 +3405,9 @@
             }
         },
         "node_modules/https-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
             "dev": true,
             "dependencies": {
                 "agent-base": "^7.0.2",
@@ -3478,9 +3450,9 @@
             ]
         },
         "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "dev": true,
             "engines": {
                 "node": ">= 4"
@@ -3545,6 +3517,7 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
             "dev": true,
             "dependencies": {
                 "once": "^1.3.0",
@@ -3738,18 +3711,18 @@
             "dev": true
         },
         "node_modules/jiti": {
-            "version": "1.19.3",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.19.3.tgz",
-            "integrity": "sha512-5eEbBDQT/jF1xg6l36P+mWGGoH9Spuy0PCdSr2dtWRDGC6ph/w9ZCL4lmESW8f8F7MwT3XKescfP0wnZWAKL9w==",
+            "version": "1.21.6",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
+            "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
             "dev": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
         },
         "node_modules/jose": {
-            "version": "4.14.4",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-4.14.4.tgz",
-            "integrity": "sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==",
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-5.6.3.tgz",
+            "integrity": "sha512-1Jh//hEEwMhNYPDDLwXHa2ePWgWiFNNUadVmguAAw2IJ6sj9mNxV5tGXJNqlMkJAybF6Lgw1mISDxTePP/187g==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -3791,18 +3764,6 @@
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
-        "node_modules/json-stable-stringify": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
-            "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
-            "dev": true,
-            "dependencies": {
-                "jsonify": "^0.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/json-to-pretty-yaml": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/json-to-pretty-yaml/-/json-to-pretty-yaml-1.2.2.tgz",
@@ -3826,15 +3787,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/jsonify": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-            "dev": true,
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/lines-and-columns": {
@@ -4037,12 +3989,12 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -4128,9 +4080,9 @@
             "dev": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -4405,9 +4357,9 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
             "dev": true
         },
         "node_modules/picomatch": {
@@ -4490,9 +4442,9 @@
             }
         },
         "node_modules/regenerator-runtime": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-            "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
+            "version": "0.14.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
             "dev": true
         },
         "node_modules/relay-runtime": {
@@ -4575,9 +4527,9 @@
             }
         },
         "node_modules/rfdc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+            "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
             "dev": true
         },
         "node_modules/run-async": {
@@ -4880,9 +4832,9 @@
             "dev": true
         },
         "node_modules/tslib": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
             "dev": true
         },
         "node_modules/type-fest": {
@@ -4898,9 +4850,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.1.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-            "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+            "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
@@ -4911,9 +4863,9 @@
             }
         },
         "node_modules/ua-parser-js": {
-            "version": "1.0.35",
-            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
-            "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.38.tgz",
+            "integrity": "sha512-Aq5ppTOfvrCMgAPneW1HfWj66Xi7XL+/mIy996R1/CLS/rcyJQm6QZdsKrUeivDFQ+Oc9Wyuwor8Ze8peEoUoQ==",
             "dev": true,
             "funding": [
                 {
@@ -4923,6 +4875,10 @@
                 {
                     "type": "paypal",
                     "url": "https://paypal.me/faisalman"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/faisalman"
                 }
             ],
             "engines": {
@@ -4938,6 +4894,12 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "dev": true
+        },
         "node_modules/unixify": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
@@ -4951,9 +4913,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.11.tgz",
-            "integrity": "sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+            "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
             "dev": true,
             "funding": [
                 {
@@ -4970,8 +4932,8 @@
                 }
             ],
             "dependencies": {
-                "escalade": "^3.1.1",
-                "picocolors": "^1.0.0"
+                "escalade": "^3.1.2",
+                "picocolors": "^1.0.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -5029,25 +4991,25 @@
             }
         },
         "node_modules/web-streams-polyfill": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-            "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+            "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
             "dev": true,
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/webcrypto-core": {
-            "version": "1.7.7",
-            "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.7.7.tgz",
-            "integrity": "sha512-7FjigXNsBfopEj+5DV2nhNpfic2vumtjjgPmeDKk45z+MJwXKKfhPB7118Pfzrmh4jqOMST6Ch37iPAHoImg5g==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.0.tgz",
+            "integrity": "sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==",
             "dev": true,
             "dependencies": {
-                "@peculiar/asn1-schema": "^2.3.6",
+                "@peculiar/asn1-schema": "^2.3.8",
                 "@peculiar/json-schema": "^1.1.12",
                 "asn1js": "^3.0.1",
-                "pvtsutils": "^1.3.2",
-                "tslib": "^2.4.0"
+                "pvtsutils": "^1.3.5",
+                "tslib": "^2.6.2"
             }
         },
         "node_modules/webidl-conversions": {
@@ -5093,9 +5055,9 @@
             "dev": true
         },
         "node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -5129,10 +5091,13 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
-            "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
+            "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
             "dev": true,
+            "bin": {
+                "yaml": "bin.mjs"
+            },
             "engines": {
                 "node": ">= 14"
             }

--- a/typegenerator/package.json
+++ b/typegenerator/package.json
@@ -12,11 +12,11 @@
         "start": "./generate.sh"
     },
     "devDependencies": {
-        "@graphql-codegen/cli": "5.0.0",
-        "@graphql-codegen/client-preset": "^4.1.0",
-        "@graphql-codegen/typescript": "4.0.1",
+        "@graphql-codegen/cli": "^5.0.0",
+        "@graphql-codegen/client-preset": "^4.3.2",
+        "@graphql-codegen/typescript": "^4.0.1",
         "get-graphql-schema": "^2.1.2",
-        "graphql": "^16.8.0",
+        "graphql": "^16.9.0",
         "typescript": "^5.5.2"
     }
 }

--- a/typegenerator/package.json
+++ b/typegenerator/package.json
@@ -6,7 +6,7 @@
     "license": "Apache-2.0",
     "type": "module",
     "engines": {
-        "node": ">=18"
+        "node": ">=20"
     },
     "scripts": {
         "start": "./generate.sh"
@@ -17,6 +17,6 @@
         "@graphql-codegen/typescript": "4.0.1",
         "get-graphql-schema": "^2.1.2",
         "graphql": "^16.8.0",
-        "typescript": "^5.1.3"
+        "typescript": "^5.5.2"
     }
 }


### PR DESCRIPTION
**SCHEMA**

Update to 9.3 schema and use standards-credential-mode

**VERSION PROBLEMS FIXED**

- There was an import problem in `migration-configuration.xml`, where previously `dbClient.*` was allowed but it now needs to be `dbClient`. 
- There was a problem where tags now need to be included in the XML configuration before you can set them when saving a DB client.

Note also that since this repo was written the DB clients are not also available in the admin UI.

**ISSUES REPORTED**

- Fixed [this reported issue](https://github.com/curityio/database-client-migration-example/issues/11) where a fractional secondary expiration time was not handled correctly
- Fixed [this reported issue](https://github.com/curityio/database-client-migration-example/issues/12) where an implicit flow client did not get migrated correctly.
- Fixed [this reported issue](https://github.com/curityio/database-client-migration-example/issues/13) by setting a large `first` size to override the GraphQL DEFAULT_PAGE_SIZE value of 20

**TYPE CHANGES**

I updated dependencies and regenerated the `databaseClient.ts` file, which has a couple of changes. These are just a TypeScript naming thing and the actual objects are unchanged, but good to avoid warnings for developers looking at this:

- ClientAuthenticationInput -> ClientAuthenticationCreateInput
- ClientAuthenticationVerifierInput -> ClientAuthenticationVerifierCreateInput
- IdTokenInput -> IdTokenCreateInput